### PR TITLE
Add bazel-mode.el, which defines bazel-mode.

### DIFF
--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -1,5 +1,5 @@
-;;; -*- lexical-binding: t; -*-
-;;; bazel-mode.el --- Emacs major mode for editing Bazel BUILD and WORKSPACE files
+;;; bazel-mode.el --- Emacs major mode for editing Bazel BUILD and WORKSPACE files -*- lexical-binding: t; -*-
+
 
 ;; Copyright (C) 2018 Google LLC
 ;; Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,48 +43,10 @@
 (defconst bazel-keywords
   '("for"))
 
-(defconst cc-rules
-  '("cc_binary" "cc_inc_library" "cc_library" "cc_proto_library" "cc_test"))
-
-(defconst extra-actions-rules
-  '("action_listener" "extra_action"))
-
-;; See https://docs.bazel.build/versions/master/be/functions.html.
-(defconst function-rules
-  '("exports_files" "glob" "licenses" "load" "package" "package_group" "select"
-	"workspace"))
-
-(defconst general-rules
-  '("alias" "config_setting" "filegroup" "genrule" "genquery" "test_suite"))
-
-(defconst java-rules
-  '("java_binary" "java_import" "java_library" "java_lite_proto_library"
-	"java_plugin" "java_proto_library" "java_test" "java_runtime"
-	"java_runtime_suite" "java_toolchain"))
-
-(defconst platform-rules
-  '("constraint_setting" "constraint_value" "platform"))
-
-(defconst protobuf-rules
-  '("proto_lang_toolchain" "proto_library"))
-
-(defconst python-rules
-  '("py_binary" "py_library" "py_proto_library" "py_test"))
-
-(defconst workspace-rules
-  '("bind" "git_repository" "http_archive" "http_file" "http_jar"
-	"local_repository" "maven_jar" "maven_server" "new_git_repository"
-	"new_http_archive" "new_local_repository" "xcode_config" "xcode_version"))
-
 (defun bazel-mode--sort-strings-longest-first (l)
   "Sort strings by length and put the longest strings first.
 L is the list of strings to sort."
   (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
-
-(defconst bazel-functions
-  (bazel-mode--sort-strings-longest-first
-   (append cc-rules extra-actions-rules function-rules general-rules java-rules
-		   platform-rules protobuf-rules python-rules workspace-rules)))
 
 ;; arguments to functions
 (defconst bind-args
@@ -151,7 +113,6 @@ L is the list of strings to sort."
 
 ;; generate regex string for each category of keywords
 (defvar bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
-(defvar bazel-functions-regexp (regexp-opt bazel-functions 'words))
 (defvar bazel-type-regexp (regexp-opt bazel-types 'words))
 (defvar bazel-constant-regexp (regexp-opt bazel-constants 'words))
 (defvar bazel-event-regexp (regexp-opt bazel-events 'words))
@@ -159,7 +120,6 @@ L is the list of strings to sort."
 (defvar bazel-font-lock-keywords
       `(
         (,bazel-keywords-regexp . font-lock-keyword-face)
-        (,bazel-functions-regexp . font-lock-function-name-face)
         (,bazel-type-regexp . font-lock-type-face)
         (,bazel-constant-regexp . font-lock-constant-face)
         (,bazel-event-regexp . font-lock-builtin-face)

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -76,6 +76,11 @@
 	"local_repository" "maven_jar" "maven_server" "new_git_repository"
 	"new_http_archive" "new_local_repository" "xcode_config" "xcode_version"))
 
+(defun bazel-mode--sort-strings-longest-first (l)
+  "Sort strings by length and put the longest strings first.
+L is the list of strings to sort."
+  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
+
 (defconst bazel-functions
   (bazel-mode--sort-strings-longest-first
    (append cc-rules extra-actions-rules function-rules general-rules java-rules
@@ -150,11 +155,6 @@
 (defvar bazel-type-regexp (regexp-opt bazel-types 'words))
 (defvar bazel-constant-regexp (regexp-opt bazel-constants 'words))
 (defvar bazel-event-regexp (regexp-opt bazel-events 'words))
-
-(defun bazel-mode--sort-strings-longest-first (l)
-  "Sort strings by length and put the longest strings first.
-L is the list of strings to sort."
-  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
 
 (defvar bazel-font-lock-keywords
       `(

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -15,12 +15,53 @@
 ;;
 ;;; Commentary:
 ;;
+;; This package provides Emacs bazel-mode which performs syntax
+;; highlighting for Bazel WORKSPACE and BUILD files.
+;;
+;; -*- lexical-binding: t; -*-
 ;;; Code:
 
-(defun bazel-mode--sort-strings-longest-first (l)
-  "Sort strings by length and put the longest strings first.
-L is the list of strings to sort."
-  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
+;;;###autoload
+(define-derived-mode bazel-mode prog-mode "Bazel"
+  "Major mode for editing Bazel BUILD and WORKSPACE files."
+  (setq font-lock-defaults '((bazel-font-lock-keywords))))
+
+(defvar bazel-font-lock-keywords
+      `(
+        (,bazel-keywords-regexp . font-lock-keyword-face)
+        (,bazel-functions-regexp . font-lock-function-name-face)
+        (,bazel-type-regexp . font-lock-type-face)
+        (,bazel-constant-regexp . font-lock-constant-face)
+        (,bazel-event-regexp . font-lock-builtin-face)
+        ;; note: order above matters. in general, longer words first.
+        ))
+
+(defvar bazel-mode-syntax-table
+  (let ((table (make-syntax-table)))
+	;; comments start with '#' and end with line break
+	(modify-syntax-entry ?# "<" table)
+	(modify-syntax-entry ?\n ">" table)
+	table))
+
+(defconst bazel-types
+  (bazel-mode--sort-strings-longest-first
+    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
+	  config-setting-args genrule-args genquery-args git-repository-args glob-args
+	  http-args java-buildrule-args local-repository-args maven-args
+	  new-repository-args package-args py-buildrule-args)))
+
+(defconst bazel-constants
+  '("true"))
+
+(defconst bazel-events
+  '())
+
+;; generate regex string for each category of keywords
+(setq bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
+(setq bazel-functions-regexp (regexp-opt bazel-functions 'words))
+(setq bazel-type-regexp (regexp-opt bazel-types 'words))
+(setq bazel-constant-regexp (regexp-opt bazel-constants 'words))
+(setq bazel-event-regexp (regexp-opt bazel-events 'words))
 
 ;; define several category of keywords
 (defconst bazel-keywords
@@ -120,47 +161,10 @@ L is the list of strings to sort."
   '("default_python_version" "default_runtime" "files" "imports" "interpreter"
     "interpreter_path" "main" "protoc" "srcs_version"))
 
-(defconst bazel-types
-  (bazel-mode--sort-strings-longest-first
-    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
-	  config-setting-args genrule-args genquery-args git-repository-args glob-args
-	  http-args java-buildrule-args local-repository-args maven-args
-	  new-repository-args package-args py-buildrule-args)))
-
-(defconst bazel-constants
-  '("true"))
-
-(defconst bazel-events
-  '())
-
-;; generate regex string for each category of keywords
-(setq bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
-(setq bazel-functions-regexp (regexp-opt bazel-functions 'words))
-(setq bazel-type-regexp (regexp-opt bazel-types 'words))
-(setq bazel-constant-regexp (regexp-opt bazel-constants 'words))
-(setq bazel-event-regexp (regexp-opt bazel-events 'words))
-
-(defvar bazel-font-lock-keywords
-      `(
-        (,bazel-keywords-regexp . font-lock-keyword-face)
-        (,bazel-functions-regexp . font-lock-function-name-face)
-        (,bazel-type-regexp . font-lock-type-face)
-        (,bazel-constant-regexp . font-lock-constant-face)
-        (,bazel-event-regexp . font-lock-builtin-face)
-        ;; note: order above matters. in general, longer words first.
-        ))
-
-(defvar bazel-mode-syntax-table
-  (let ((table (make-syntax-table)))
-	;; comments start with '#' and end with line break
-	(modify-syntax-entry ?# "<" table)
-	(modify-syntax-entry ?\n ">" table)
-	table))
-
-;;;###autoload
-(define-derived-mode bazel-mode prog-mode "Bazel"
-  "Major mode for editing Bazel BUILD and WORKSPACE files"
-  (setq font-lock-defaults '((bazel-font-lock-keywords))))
+(defun bazel-mode--sort-strings-longest-first (l)
+  "Sort strings by length and put the longest strings first.
+L is the list of strings to sort."
+  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
 
 (provide 'bazel-mode)
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -16,115 +16,14 @@
 ;;
 ;;; Commentary:
 ;;
-;; This package provides Emacs bazel-mode which performs syntax
-;; highlighting for Bazel WORKSPACE and BUILD files.
+;; This package provides Emacs bazel-mode, a major mode for editing Bazel
+;; BUILD and WORKSPACE files.
 ;;
 ;;; Code:
 
 ;;;###autoload
 (define-derived-mode bazel-mode prog-mode "Bazel"
-  "Major mode for editing Bazel BUILD and WORKSPACE files."
-  (setq font-lock-defaults '((bazel-font-lock-keywords))))
-
-(defvar bazel-mode-syntax-table
-  (let ((table (make-syntax-table)))
-	;; comments start with '#' and end with line break
-	(modify-syntax-entry ?# "<" table)
-	(modify-syntax-entry ?\n ">" table)
-	table))
-
-(defconst bazel-constants
-  '("true"))
-
-(defconst bazel-events
-  '())
-
-;; define several category of keywords
-(defconst bazel-keywords
-  '("for"))
-
-(defun bazel-mode--sort-strings-longest-first (l)
-  "Sort strings by length and put the longest strings first.
-L is the list of strings to sort."
-  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
-
-;; arguments to functions
-(defconst bind-args
-  '("actual"))
-
-(defconst cc-buildrule-args
-  '("copts" "defines" "hdrs" "includes" "include_prefix" "linkopts" "linkshared"
-	"linkstatic" "malloc" "nocopts" "strip_include_prefix" "textual_headers"))
-
-(defconst common-buildrule-args
-  '("deps" "data" "args" "defines" "stamp" "toolchains"))
-
-(defconst common-testrule-args
-  '("local" "flaky" "shard_count" "size" "timeout"))
-
-(defconst config-setting-args
-  '("values"))
-
-(defconst genrule-args
-  '("cmd" "compatible_with" "deprecation" "distribs" "executable" "features"
-	"licenses" "message" "name" "output_licenses" "output_to_bindir" "outs"
-	"restricted_to" "srcs" "tags" "testonly" "tools" "visibility"))
-
-(defconst genquery-args
-  '("deps" "data" "expression" "opts" "scope" "strict"))
-
-(defconst git-repository-args
-  '("commit" "init_submodules" "remote" "sha256"))
-
-(defconst glob-args
-  '("exclude" "exclude_directories" "include"))
-
-(defconst http-args
-  '("executable" "strip_prefix" "type" "url" "urls"))
-
-(defconst java-buildrule-args
-  '("classpath_resources" "create_executable" "deploy_manifest_lines"
-	"javacopts" "jvm_flags" "launcher" "main_class" "output_licenses" "plugins"
-	"resources" "resource_jars" "resource_strip_prefix" "restricted_to"
-	"runtime_deps" "use_testrunner"))
-
-(defconst local-repository-args
-  '("path"))
-
-(defconst maven-args
-  '("artifact" "repository" "server" "sha1"))
-
-(defconst new-repository-args
-  '("build_file" "build_file_content" "workspace_file" "workspace_file_content"))
-
-(defconst package-args
-  '("default_deprecation" "default_testonly" "default_visibility"))
-
-(defconst py-buildrule-args
-  '("default_python_version" "default_runtime" "files" "imports" "interpreter"
-    "interpreter_path" "main" "protoc" "srcs_version"))
-
-(defconst bazel-types
-  (bazel-mode--sort-strings-longest-first
-    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
-	  config-setting-args genrule-args genquery-args git-repository-args glob-args
-	  http-args java-buildrule-args local-repository-args maven-args
-	  new-repository-args package-args py-buildrule-args)))
-
-;; generate regex string for each category of keywords
-(defconst bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
-(defconst bazel-type-regexp (regexp-opt bazel-types 'words))
-(defconst bazel-constant-regexp (regexp-opt bazel-constants 'words))
-(defconst bazel-event-regexp (regexp-opt bazel-events 'words))
-
-(defconst bazel-font-lock-keywords
-      `(
-        (,bazel-keywords-regexp . font-lock-keyword-face)
-        (,bazel-type-regexp . font-lock-type-face)
-        (,bazel-constant-regexp . font-lock-constant-face)
-        (,bazel-event-regexp . font-lock-builtin-face)
-        ;; note: order above matters. in general, longer words first.
-        ))
+  "Major mode for editing Bazel BUILD and WORKSPACE files.")
 
 (provide 'bazel-mode)
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -1,201 +1,136 @@
-(defun sort-strings-longest-first (l)
+;;; bazel-mode.el --- Emacs major mode for editing Bazel BUILD and WORKSPACE files
+
+;; Copyright (C) 2018 Google LLC
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;      http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+;;; Commentary:
+;;
+;;; Code:
+
+(defun bazel-mode--sort-strings-longest-first (l)
+  "Sort strings by length and put the longest strings first.
+L is the list of strings to sort."
   (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
 
 ;; define several category of keywords
-(setq bazel-keywords
+(defconst bazel-keywords
   '("for"))
 
-(setq android-rules
-  '("android_binary" "aar_import" "android_library" "android_device"
-	"android_ndk_repository" "android_sdk_repository"))
-
-(setq apple-rules
-  '("apple_genrule" "swift_library"))
-
-(setq cc-rules
+(defconst cc-rules
   '("cc_binary" "cc_inc_library" "cc_library" "cc_proto_library" "cc_test"))
 
-(setq closure-rules
-  '("closure_css_binary" "closure_css_library" "closure_java_template_library"
-	"closure_js_binary" "closure_js_deps" "closure_js_library"
-	"closure_js_proto_library" "closure_js_template_library" "closure_js_test"
-	"closure_py_template_library" "phantomjs_test"))
-
-(setq d-rules
-  '("d_library" "d_source_library" "d_binary" "d_test" "d_docs"))
-
-(setq docker-rules
-  '("docker_build" "docker_bundle" "docker_pull" "docker_push"))
-
-(setq dotnet-rules
-  '("csharp_binary" "csharp_library" "csharp_nunit_test" "dll_import"
-	"new_nuget_package" "nuget_package"))
-
-(setq extra-actions-rules
+(defconst extra-actions-rules
   '("action_listener" "extra_action"))
 
-(setq function-rules
+;; See https://docs.bazel.build/versions/master/be/functions.html.
+(defconst function-rules
   '("exports_files" "glob" "licenses" "load" "package" "package_group" "select"
 	"workspace"))
 
-(setq general-rules
+(defconst general-rules
   '("alias" "config_setting" "filegroup" "genrule" "genquery" "test_suite"))
 
-(setq go-rules
-  '("cgo_library" "go_binary" "go_embed_data" "go_library" "go_prefix"
-	"go_proto_library" "go_repositories" "go_repository" "go_test"))
-
-(setq groovy-rules
-  '("groovy_and_java_library" "groovy_binary" "groovy_junit_test"
-	"groovy_library" "spock_test"))
-
-(setq java-appengine-rules
-  '("appengine_war" "java_war" "py_appengine_binary" "py_appengine_test"))
-
-(setq java-rules
+(defconst java-rules
   '("java_binary" "java_import" "java_library" "java_lite_proto_library"
 	"java_plugin" "java_proto_library" "java_test" "java_runtime"
 	"java_runtime_suite" "java_toolchain"))
 
-(setq jsonnet-rules
-  '("jsonnet_library" "jsonnet_repositories" "jsonnet_to_json"
-	"jsonnet_to_json_test"))
-
-(setq package-rules
-  '("pkg_deb" "pkg_rpm" "pkg_tar"))
-
-(setq objc-rules
-  '("apple_binary" "apple_static_library" "apple_watch1_extension"
-	"apple_watch2_extension" "apple_watch_extension_binary" "ios_application"
-	"ios_device" "ios_extension" "ios_extension_binary" "ios_test"
-	"j2objc_library" "objc_binary" "objc_bundle" "objc_bundle_library"
-	"objc_framework" "objc_import" "objc_library" "objc_proto_library"))
-
-;; github.com/google/subpar
-(setq subpar-rules
-  '("par_binary" "parfile"))
-
-(setq perl-rules
-  '("perl_binary" "perl_library" "perl_test"))
-
-(setq platform-rules
+(defconst platform-rules
   '("constraint_setting" "constraint_value" "platform"))
 
-(setq protobuf-rules
+(defconst protobuf-rules
   '("proto_lang_toolchain" "proto_library"))
 
-(setq python-rules
+(defconst python-rules
   '("py_binary" "py_library" "py_proto_library" "py_test"))
 
-(setq rust-rules
-  '("rust_bench_test" "rust_binary"  "rust_doc" "rust_doc_test" "rust_library"
-	"rust_repositories" "rust_test"))
-
-(setq sass-rules
-  '("sass_binary" "sass_library"))
-
-(setq scala-rules
-  '("scala_binary" "scala_library" "scala_macro_library" "scala_test"))
-
-(setq shell-rules
-  '("sh_binary" "sh_library" "sh_test"))
-
-(setq typescript-rules
-  '("ts_library"))
-
-(setq webtesting-rules
-  '("go_web_test_suite" "java_web_test_suite" "py_web_test_suite" "web_test"
-	"web_test_repositories" "web_test_suite"))
-
-(setq workspace-rules
+(defconst workspace-rules
   '("bind" "git_repository" "http_archive" "http_file" "http_jar"
 	"local_repository" "maven_jar" "maven_server" "new_git_repository"
 	"new_http_archive" "new_local_repository" "xcode_config" "xcode_version"))
 
-(setq bazel-functions
-  (sort-strings-longest-first
-   (append apple-rules android-rules cc-rules closure-rules d-rules docker-rules
-		   dotnet-rules extra-actions-rules function-rules general-rules go-rules
-		   groovy-rules java-appengine-rules java-rules jsonnet-rules objc-rules
-		   perl-rules platform-rules protobuf-rules python-rules rust-rules sass-rules
-		   shell-rules subpar-rules typescript-rules webtesting-rules
-		   workspace-rules)))
+(defconst bazel-functions
+  (bazel-mode--sort-strings-longest-first
+   (append cc-rules extra-actions-rules function-rules general-rules java-rules
+		   platform-rules protobuf-rules python-rules workspace-rules)))
 
 ;; arguments to functions
-(setq bind-args
+(defconst bind-args
   '("actual"))
 
-(setq cc-buildrule-args
+(defconst cc-buildrule-args
   '("copts" "defines" "hdrs" "includes" "include_prefix" "linkopts" "linkshared"
 	"linkstatic" "malloc" "nocopts" "strip_include_prefix" "textual_headers"))
 
-(setq common-buildrule-args
+(defconst common-buildrule-args
   '("deps" "data" "args" "defines" "stamp" "toolchains"))
 
-(setq common-testrule-args
+(defconst common-testrule-args
   '("local" "flaky" "shard_count" "size" "timeout"))
 
-(setq config-setting-args
+(defconst config-setting-args
   '("values"))
 
-(setq genrule-args
+(defconst genrule-args
   '("cmd" "compatible_with" "deprecation" "distribs" "executable" "features"
 	"licenses" "message" "name" "output_licenses" "output_to_bindir" "outs"
 	"restricted_to" "srcs" "tags" "testonly" "tools" "visibility"))
 
-(setq genquery-args
+(defconst genquery-args
   '("deps" "data" "expression" "opts" "scope" "strict"))
 
-(setq git-repository-args
+(defconst git-repository-args
   '("commit" "init_submodules" "remote" "sha256"))
 
-(setq glob-args
+(defconst glob-args
   '("exclude" "exclude_directories" "include"))
 
-(setq go-repositories-args
-  '("go_version"))
-
-(setq go-repository-args
-  '("build_file_generation" "build_file_name" "build_tags" "importpath"
-	"go-prefix" "tag" "vcs"))
-
-(setq http-args
+(defconst http-args
   '("executable" "strip_prefix" "type" "url" "urls"))
 
-(setq java-buildrule-args
+(defconst java-buildrule-args
   '("classpath_resources" "create_executable" "deploy_manifest_lines"
 	"javacopts" "jvm_flags" "launcher" "main_class" "output_licenses" "plugins"
 	"resources" "resource_jars" "resource_strip_prefix" "restricted_to"
 	"runtime_deps" "use_testrunner"))
 
-(setq local-repository-args
+(defconst local-repository-args
   '("path"))
 
-(setq maven-args
+(defconst maven-args
   '("artifact" "repository" "server" "sha1"))
 
-(setq new-repository-args
+(defconst new-repository-args
   '("build_file" "build_file_content" "workspace_file" "workspace_file_content"))
 
-(setq package-args
+(defconst package-args
   '("default_deprecation" "default_testonly" "default_visibility"))
 
-(setq py-buildrule-args
+(defconst py-buildrule-args
   '("default_python_version" "default_runtime" "files" "imports" "interpreter"
     "interpreter_path" "main" "protoc" "srcs_version"))
 
-(setq bazel-types
-  (sort-strings-longest-first
+(defconst bazel-types
+  (bazel-mode--sort-strings-longest-first
     (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
 	  config-setting-args genrule-args genquery-args git-repository-args glob-args
-	  go-repositories-args go-repository-args http-args java-buildrule-args
-	  local-repository-args maven-args new-repository-args package-args
-	  py-buildrule-args)))
+	  http-args java-buildrule-args local-repository-args maven-args
+	  new-repository-args package-args py-buildrule-args)))
 
-(setq bazel-constants
+(defconst bazel-constants
   '("true"))
 
-(setq bazel-events
+(defconst bazel-events
   '())
 
 ;; generate regex string for each category of keywords
@@ -205,20 +140,17 @@
 (setq bazel-constant-regexp (regexp-opt bazel-constants 'words))
 (setq bazel-event-regexp (regexp-opt bazel-events 'words))
 
-;; create the list for font-lock.
-;; each category of keyword is given a particular face
-(setq bazel-font-lock-keywords
+(defvar bazel-font-lock-keywords
       `(
         (,bazel-keywords-regexp . font-lock-keyword-face)
         (,bazel-functions-regexp . font-lock-function-name-face)
         (,bazel-type-regexp . font-lock-type-face)
         (,bazel-constant-regexp . font-lock-constant-face)
         (,bazel-event-regexp . font-lock-builtin-face)
-        ;; note: order above matters, because once colored, that part won't change.
-        ;; in general, longer words first
+        ;; note: order above matters. in general, longer words first.
         ))
 
-(setq bazel-mode-syntax-table
+(defvar bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
 	;; comments start with '#' and end with line break
 	(modify-syntax-entry ?# "<" table)
@@ -228,13 +160,8 @@
 ;;;###autoload
 (define-derived-mode bazel-mode prog-mode "Bazel"
   "Major mode for editing Bazel BUILD and WORKSPACE files"
+  (setq font-lock-defaults '((bazel-font-lock-keywords))))
 
-  ;; code for syntax highlighting
-  (setq font-lock-defaults '((bazel-font-lock-keywords)))
-
-  (set-syntax-table bazel-mode-syntax-table))
-
-;; add the mode to the `features' list
 (provide 'bazel-mode)
 
 ;;; bazel-mode.el ends here

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -1,0 +1,240 @@
+(defun sort-strings-longest-first (l)
+  (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
+
+;; define several category of keywords
+(setq bazel-keywords
+  '("for"))
+
+(setq android-rules
+  '("android_binary" "aar_import" "android_library" "android_device"
+	"android_ndk_repository" "android_sdk_repository"))
+
+(setq apple-rules
+  '("apple_genrule" "swift_library"))
+
+(setq cc-rules
+  '("cc_binary" "cc_inc_library" "cc_library" "cc_proto_library" "cc_test"))
+
+(setq closure-rules
+  '("closure_css_binary" "closure_css_library" "closure_java_template_library"
+	"closure_js_binary" "closure_js_deps" "closure_js_library"
+	"closure_js_proto_library" "closure_js_template_library" "closure_js_test"
+	"closure_py_template_library" "phantomjs_test"))
+
+(setq d-rules
+  '("d_library" "d_source_library" "d_binary" "d_test" "d_docs"))
+
+(setq docker-rules
+  '("docker_build" "docker_bundle" "docker_pull" "docker_push"))
+
+(setq dotnet-rules
+  '("csharp_binary" "csharp_library" "csharp_nunit_test" "dll_import"
+	"new_nuget_package" "nuget_package"))
+
+(setq extra-actions-rules
+  '("action_listener" "extra_action"))
+
+(setq function-rules
+  '("exports_files" "glob" "licenses" "load" "package" "package_group" "select"
+	"workspace"))
+
+(setq general-rules
+  '("alias" "config_setting" "filegroup" "genrule" "genquery" "test_suite"))
+
+(setq go-rules
+  '("cgo_library" "go_binary" "go_embed_data" "go_library" "go_prefix"
+	"go_proto_library" "go_repositories" "go_repository" "go_test"))
+
+(setq groovy-rules
+  '("groovy_and_java_library" "groovy_binary" "groovy_junit_test"
+	"groovy_library" "spock_test"))
+
+(setq java-appengine-rules
+  '("appengine_war" "java_war" "py_appengine_binary" "py_appengine_test"))
+
+(setq java-rules
+  '("java_binary" "java_import" "java_library" "java_lite_proto_library"
+	"java_plugin" "java_proto_library" "java_test" "java_runtime"
+	"java_runtime_suite" "java_toolchain"))
+
+(setq jsonnet-rules
+  '("jsonnet_library" "jsonnet_repositories" "jsonnet_to_json"
+	"jsonnet_to_json_test"))
+
+(setq package-rules
+  '("pkg_deb" "pkg_rpm" "pkg_tar"))
+
+(setq objc-rules
+  '("apple_binary" "apple_static_library" "apple_watch1_extension"
+	"apple_watch2_extension" "apple_watch_extension_binary" "ios_application"
+	"ios_device" "ios_extension" "ios_extension_binary" "ios_test"
+	"j2objc_library" "objc_binary" "objc_bundle" "objc_bundle_library"
+	"objc_framework" "objc_import" "objc_library" "objc_proto_library"))
+
+;; github.com/google/subpar
+(setq subpar-rules
+  '("par_binary" "parfile"))
+
+(setq perl-rules
+  '("perl_binary" "perl_library" "perl_test"))
+
+(setq platform-rules
+  '("constraint_setting" "constraint_value" "platform"))
+
+(setq protobuf-rules
+  '("proto_lang_toolchain" "proto_library"))
+
+(setq python-rules
+  '("py_binary" "py_library" "py_proto_library" "py_test"))
+
+(setq rust-rules
+  '("rust_bench_test" "rust_binary"  "rust_doc" "rust_doc_test" "rust_library"
+	"rust_repositories" "rust_test"))
+
+(setq sass-rules
+  '("sass_binary" "sass_library"))
+
+(setq scala-rules
+  '("scala_binary" "scala_library" "scala_macro_library" "scala_test"))
+
+(setq shell-rules
+  '("sh_binary" "sh_library" "sh_test"))
+
+(setq typescript-rules
+  '("ts_library"))
+
+(setq webtesting-rules
+  '("go_web_test_suite" "java_web_test_suite" "py_web_test_suite" "web_test"
+	"web_test_repositories" "web_test_suite"))
+
+(setq workspace-rules
+  '("bind" "git_repository" "http_archive" "http_file" "http_jar"
+	"local_repository" "maven_jar" "maven_server" "new_git_repository"
+	"new_http_archive" "new_local_repository" "xcode_config" "xcode_version"))
+
+(setq bazel-functions
+  (sort-strings-longest-first
+   (append apple-rules android-rules cc-rules closure-rules d-rules docker-rules
+		   dotnet-rules extra-actions-rules function-rules general-rules go-rules
+		   groovy-rules java-appengine-rules java-rules jsonnet-rules objc-rules
+		   perl-rules platform-rules protobuf-rules python-rules rust-rules sass-rules
+		   shell-rules subpar-rules typescript-rules webtesting-rules
+		   workspace-rules)))
+
+;; arguments to functions
+(setq bind-args
+  '("actual"))
+
+(setq cc-buildrule-args
+  '("copts" "defines" "hdrs" "includes" "include_prefix" "linkopts" "linkshared"
+	"linkstatic" "malloc" "nocopts" "strip_include_prefix" "textual_headers"))
+
+(setq common-buildrule-args
+  '("deps" "data" "args" "defines" "stamp" "toolchains"))
+
+(setq common-testrule-args
+  '("local" "flaky" "shard_count" "size" "timeout"))
+
+(setq config-setting-args
+  '("values"))
+
+(setq genrule-args
+  '("cmd" "compatible_with" "deprecation" "distribs" "executable" "features"
+	"licenses" "message" "name" "output_licenses" "output_to_bindir" "outs"
+	"restricted_to" "srcs" "tags" "testonly" "tools" "visibility"))
+
+(setq genquery-args
+  '("deps" "data" "expression" "opts" "scope" "strict"))
+
+(setq git-repository-args
+  '("commit" "init_submodules" "remote" "sha256"))
+
+(setq glob-args
+  '("exclude" "exclude_directories" "include"))
+
+(setq go-repositories-args
+  '("go_version"))
+
+(setq go-repository-args
+  '("build_file_generation" "build_file_name" "build_tags" "importpath"
+	"go-prefix" "tag" "vcs"))
+
+(setq http-args
+  '("executable" "strip_prefix" "type" "url" "urls"))
+
+(setq java-buildrule-args
+  '("classpath_resources" "create_executable" "deploy_manifest_lines"
+	"javacopts" "jvm_flags" "launcher" "main_class" "output_licenses" "plugins"
+	"resources" "resource_jars" "resource_strip_prefix" "restricted_to"
+	"runtime_deps" "use_testrunner"))
+
+(setq local-repository-args
+  '("path"))
+
+(setq maven-args
+  '("artifact" "repository" "server" "sha1"))
+
+(setq new-repository-args
+  '("build_file" "build_file_content" "workspace_file" "workspace_file_content"))
+
+(setq package-args
+  '("default_deprecation" "default_testonly" "default_visibility"))
+
+(setq py-buildrule-args
+  '("default_python_version" "default_runtime" "files" "imports" "interpreter"
+    "interpreter_path" "main" "protoc" "srcs_version"))
+
+(setq bazel-types
+  (sort-strings-longest-first
+    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
+	  config-setting-args genrule-args genquery-args git-repository-args glob-args
+	  go-repositories-args go-repository-args http-args java-buildrule-args
+	  local-repository-args maven-args new-repository-args package-args
+	  py-buildrule-args)))
+
+(setq bazel-constants
+  '("true"))
+
+(setq bazel-events
+  '())
+
+;; generate regex string for each category of keywords
+(setq bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
+(setq bazel-functions-regexp (regexp-opt bazel-functions 'words))
+(setq bazel-type-regexp (regexp-opt bazel-types 'words))
+(setq bazel-constant-regexp (regexp-opt bazel-constants 'words))
+(setq bazel-event-regexp (regexp-opt bazel-events 'words))
+
+;; create the list for font-lock.
+;; each category of keyword is given a particular face
+(setq bazel-font-lock-keywords
+      `(
+        (,bazel-keywords-regexp . font-lock-keyword-face)
+        (,bazel-functions-regexp . font-lock-function-name-face)
+        (,bazel-type-regexp . font-lock-type-face)
+        (,bazel-constant-regexp . font-lock-constant-face)
+        (,bazel-event-regexp . font-lock-builtin-face)
+        ;; note: order above matters, because once colored, that part won't change.
+        ;; in general, longer words first
+        ))
+
+(setq bazel-mode-syntax-table
+  (let ((table (make-syntax-table)))
+	;; comments start with '#' and end with line break
+	(modify-syntax-entry ?# "<" table)
+	(modify-syntax-entry ?\n ">" table)
+	table))
+
+;;;###autoload
+(define-derived-mode bazel-mode prog-mode "Bazel"
+  "Major mode for editing Bazel BUILD and WORKSPACE files"
+
+  ;; code for syntax highlighting
+  (setq font-lock-defaults '((bazel-font-lock-keywords)))
+
+  (set-syntax-table bazel-mode-syntax-table))
+
+;; add the mode to the `features' list
+(provide 'bazel-mode)
+
+;;; bazel-mode.el ends here

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 ;;; bazel-mode.el --- Emacs major mode for editing Bazel BUILD and WORKSPACE files
 
 ;; Copyright (C) 2018 Google LLC
@@ -18,7 +19,6 @@
 ;; This package provides Emacs bazel-mode which performs syntax
 ;; highlighting for Bazel WORKSPACE and BUILD files.
 ;;
-;; -*- lexical-binding: t; -*-
 ;;; Code:
 
 ;;;###autoload

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -112,12 +112,12 @@ L is the list of strings to sort."
 	  new-repository-args package-args py-buildrule-args)))
 
 ;; generate regex string for each category of keywords
-(defvar bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
-(defvar bazel-type-regexp (regexp-opt bazel-types 'words))
-(defvar bazel-constant-regexp (regexp-opt bazel-constants 'words))
-(defvar bazel-event-regexp (regexp-opt bazel-events 'words))
+(defconst bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
+(defconst bazel-type-regexp (regexp-opt bazel-types 'words))
+(defconst bazel-constant-regexp (regexp-opt bazel-constants 'words))
+(defconst bazel-event-regexp (regexp-opt bazel-events 'words))
 
-(defvar bazel-font-lock-keywords
+(defconst bazel-font-lock-keywords
       `(
         (,bazel-keywords-regexp . font-lock-keyword-face)
         (,bazel-type-regexp . font-lock-type-face)

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,16 +26,6 @@
   "Major mode for editing Bazel BUILD and WORKSPACE files."
   (setq font-lock-defaults '((bazel-font-lock-keywords))))
 
-(defvar bazel-font-lock-keywords
-      `(
-        (,bazel-keywords-regexp . font-lock-keyword-face)
-        (,bazel-functions-regexp . font-lock-function-name-face)
-        (,bazel-type-regexp . font-lock-type-face)
-        (,bazel-constant-regexp . font-lock-constant-face)
-        (,bazel-event-regexp . font-lock-builtin-face)
-        ;; note: order above matters. in general, longer words first.
-        ))
-
 (defvar bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
 	;; comments start with '#' and end with line break
@@ -43,25 +33,11 @@
 	(modify-syntax-entry ?\n ">" table)
 	table))
 
-(defconst bazel-types
-  (bazel-mode--sort-strings-longest-first
-    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
-	  config-setting-args genrule-args genquery-args git-repository-args glob-args
-	  http-args java-buildrule-args local-repository-args maven-args
-	  new-repository-args package-args py-buildrule-args)))
-
 (defconst bazel-constants
   '("true"))
 
 (defconst bazel-events
   '())
-
-;; generate regex string for each category of keywords
-(setq bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
-(setq bazel-functions-regexp (regexp-opt bazel-functions 'words))
-(setq bazel-type-regexp (regexp-opt bazel-types 'words))
-(setq bazel-constant-regexp (regexp-opt bazel-constants 'words))
-(setq bazel-event-regexp (regexp-opt bazel-events 'words))
 
 ;; define several category of keywords
 (defconst bazel-keywords
@@ -161,10 +137,34 @@
   '("default_python_version" "default_runtime" "files" "imports" "interpreter"
     "interpreter_path" "main" "protoc" "srcs_version"))
 
+(defconst bazel-types
+  (bazel-mode--sort-strings-longest-first
+    (append bind-args cc-buildrule-args common-buildrule-args common-testrule-args
+	  config-setting-args genrule-args genquery-args git-repository-args glob-args
+	  http-args java-buildrule-args local-repository-args maven-args
+	  new-repository-args package-args py-buildrule-args)))
+
+;; generate regex string for each category of keywords
+(defvar bazel-keywords-regexp (regexp-opt bazel-keywords 'words))
+(defvar bazel-functions-regexp (regexp-opt bazel-functions 'words))
+(defvar bazel-type-regexp (regexp-opt bazel-types 'words))
+(defvar bazel-constant-regexp (regexp-opt bazel-constants 'words))
+(defvar bazel-event-regexp (regexp-opt bazel-events 'words))
+
 (defun bazel-mode--sort-strings-longest-first (l)
   "Sort strings by length and put the longest strings first.
 L is the list of strings to sort."
   (sort l #'(lambda (s1 s2) (> (length s1) (length s2)))))
+
+(defvar bazel-font-lock-keywords
+      `(
+        (,bazel-keywords-regexp . font-lock-keyword-face)
+        (,bazel-functions-regexp . font-lock-function-name-face)
+        (,bazel-type-regexp . font-lock-type-face)
+        (,bazel-constant-regexp . font-lock-constant-face)
+        (,bazel-event-regexp . font-lock-builtin-face)
+        ;; note: order above matters. in general, longer words first.
+        ))
 
 (provide 'bazel-mode)
 


### PR DESCRIPTION
Defines basic syntax highlighting for standard Bazel keywords.