### PR TITLE
Adding interactive buildifier.

### DIFF
--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -44,7 +44,7 @@
              (call-process-region
               (point-min) (point-max) buildifier-cmd t t nil "--type=build")))
         (unwind-protect
-          (if (zerop return-code)
+          (if (eq return-code 0)
               (progn
                 (set-buffer input-buffer)
                 (replace-buffer-contents buildifier-buffer)

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -38,6 +38,7 @@
   (interactive "*")
   (let ((input-buffer (current-buffer))
         (buildifier-buffer (get-buffer-create "*buildifier*"))
+        ;; Run buildifier on a file to support remote BUILD files.
         (temp-file (make-nearby-temp-file "buildifier")))
     (write-region nil nil temp-file nil 1)
     (with-current-buffer buildifier-buffer

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,12 +26,12 @@
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom bazel-mode--buildifier-cmd "buildifier"
+(defcustom bazel-mode-buildifier-cmd "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel-mode)
 
-(defun buildifier ()
+(defun bazel-mode-buildifier ()
   "Format current buffer using buildifier."
   (interactive "*")
   (let ((build-file-contents (buffer-string))

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,26 +26,27 @@
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom buildifier-cmd "buildifier"
+(defcustom bazel-mode--buildifier-cmd "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel-mode)
 
-(defun bazel-mode--buildifier ()
+(defun buildifier ()
   "Format current buffer using buildifier."
-  (interactive)
+  (interactive "*")
   (let ((build-file-contents (buffer-string))
         (input-buffer (current-buffer))
-		(buildifier-buffer (get-buffer-create "*buildifier*")))
+        (buildifier-buffer (get-buffer-create "*buildifier*")))
     (with-current-buffer buildifier-buffer
       (erase-buffer)
       (insert build-file-contents)
       (let ((return-code
-             (call-process-region (point-min) (point-max) buildifier-cmd t t)))
+             (call-process-region
+              (point-min) (point-max) buildifier-cmd t t nil "--type=build")))
         (unwind-protect
           (if (zerop return-code)
               (progn
-				(set-buffer input-buffer)
+                (set-buffer input-buffer)
                 (replace-buffer-contents buildifier-buffer)
                 (kill-buffer buildifier-buffer))
               (set-buffer-modified-p nil)

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -34,15 +34,13 @@
 (defun bazel-mode-buildifier ()
   "Format current buffer using buildifier."
   (interactive "*")
-  (let ((build-file-contents (buffer-string))
+  (let ((temp-file (make-temp-file "buildifier" nil nil (buffer-string)))
         (input-buffer (current-buffer))
         (buildifier-buffer (get-buffer-create "*buildifier*")))
     (with-current-buffer buildifier-buffer
       (erase-buffer)
-      (insert build-file-contents)
       (let ((return-code
-             (call-process-region
-              (point-min) (point-max) buildifier-cmd t t nil "--type=build")))
+             (process-file buildifier-cmd temp-file buildifier-buffer nil "-type=build")))
         (unwind-protect
           (if (eq return-code 0)
               (progn


### PR DESCRIPTION
bazel-mode's buildifier command can be invoked to run Buildifier (https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md) on the current buffer. 

This is a first step on #5. A later PR can add a on-save hook.