### PR TITLE
Adding before-save-hook which runs buildifier.

### DIFF
--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,7 +26,7 @@
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom bazel-mode-buildifier-command "buildifier"
+(defcustom bazel-mode-buildifier-cmd "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel-mode
@@ -34,7 +34,7 @@
           "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))
 
 (defcustom bazel-mode-buildifier-before-save nil
-  "Specifies whether to run buildifer in 'before-save-hook'."
+  "Specifies whether to run buildifer in `before-save-hook'."
   :type 'boolean
   :group 'bazel-mode
   :link '(url-link
@@ -69,7 +69,7 @@
       (delete-file buildifier-error-file))))
 
 (defun bazel-mode--buildifier-before-save-hook ()
-  "Run buildifer as a 'before-save-hook'."
+  "Run buildifer in `before-save-hook'."
   (when bazel-mode-buildifier-before-save
     (bazel-mode-buildifier)))
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -33,6 +33,13 @@
   :link '(url-link
           "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))
 
+(defcustom bazel-mode-buildifier-before-save nil
+  "Specifies whether to run buildifer in 'before-save-hook'."
+  :type 'boolean
+  :group 'bazel-mode
+  :link '(url-link
+          "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))
+
 (defun bazel-mode-buildifier ()
   "Format current buffer using buildifier."
   (interactive "*")
@@ -60,6 +67,11 @@
       (delete-file buildifier-input-file)
       (delete-file buildifier-error-file))))
 
+(defun bazel-mode--buildifier-before-save-hook ()
+  "Run buildifer as a 'before-save-hook'."
+  (when bazel-mode-buildifier-before-save
+    (bazel-mode-buildifier)))
+
 (defconst bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
     ;; single line comment start
@@ -76,7 +88,8 @@
   (setq-local comment-start-skip "#+")
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
-  (setq-local font-lock-defaults '(nil)))
+  (setq-local font-lock-defaults '(nil))
+  (add-hook 'before-save-hook 'bazel-mode--buildifier-before-save-hook))
 
 (provide 'bazel-mode)
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -55,7 +55,7 @@
         (setq-local inhibit-read-only t)
         (erase-buffer)
         (let ((return-code
-               (process-file bazel-mode-buildifier-command buildifier-input-file
+               (process-file bazel-mode-buildifier-cmd buildifier-input-file
                              `(t ,buildifier-error-file) nil "-type=build")))
           (if (eq return-code 0)
               (progn

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,7 +26,7 @@
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom bazel-mode-buildifier-cmd "buildifier"
+(defcustom bazel-mode-buildifier-command "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel-mode
@@ -38,7 +38,8 @@
   :type 'boolean
   :group 'bazel-mode
   :link '(url-link
-          "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))
+          "https://github.com/bazelbuild/buildtools/tree/master/buildifier")
+  :risky t)
 
 (defun bazel-mode-buildifier ()
   "Format current buffer using buildifier."
@@ -54,7 +55,7 @@
         (setq-local inhibit-read-only t)
         (erase-buffer)
         (let ((return-code
-               (process-file bazel-mode-buildifier-cmd buildifier-input-file
+               (process-file bazel-mode-buildifier-command buildifier-input-file
                              `(t ,buildifier-error-file) nil "-type=build")))
           (if (eq return-code 0)
               (progn
@@ -89,7 +90,8 @@
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
   (setq-local font-lock-defaults '(nil))
-  (add-hook 'before-save-hook 'bazel-mode--buildifier-before-save-hook))
+  (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
+            nil :local))
 
 (provide 'bazel-mode)
 


### PR DESCRIPTION
Changes:
- Adds a customizable boolean bazel-mode-buildifier-before-save.
- Adds bazel-mode--buildifier-before-save-hook, which runs buildifier if bazel-mode-buildifier-before-save is true, and adds this as a before-save-hook to bazel-mode.

Fixes #5 