### PR TITLE
Don't require a BUILD file

### DIFF
--- a/bazel-build.el
+++ b/bazel-build.el
@@ -46,13 +46,12 @@
 
 (defun bazel-build--read-target (prompt)
   "Read a Bazel build target from the minibuffer.  PROMPT is a read-only prompt."
-  (let* ((file-name (buffer-file-name))
+  (let* ((file-name (or (buffer-file-name) default-directory))
          (workspace-root
           (or (bazel-build--find-workspace-root file-name)
               (user-error "Not in a Bazel workspace.  No WORKSPACE file found")))
          (package-name
-          (or (bazel-build--extract-package-name file-name workspace-root)
-              (user-error "Not in a Bazel package.  No BUILD file found")))
+          (bazel-build--extract-package-name file-name workspace-root))
          (initial-input (concat "//" package-name)))
     (read-string prompt initial-input)))
 


### PR DESCRIPTION
I like to start Bazel from the magit window, but that failed with this package. First because that buffer is not associated with a file. I fixed that with the `default-directory` change.

Then it failed with the error `"Not in a Bazel package.  No BUILD file found"`. I fixed that by simply defaulting to nothing in the prompt.