### PR TITLE
Rename bazel-mode-buildifier-cmd to bazel-mode-buildifier-command.

### DIFF
--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -26,7 +26,7 @@
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom bazel-mode-buildifier-cmd "buildifier"
+(defcustom bazel-mode-buildifier-command "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel-mode
@@ -55,7 +55,7 @@
         (setq-local inhibit-read-only t)
         (erase-buffer)
         (let ((return-code
-               (process-file bazel-mode-buildifier-cmd buildifier-input-file
+               (process-file bazel-mode-buildifier-command buildifier-input-file
                              `(t ,buildifier-error-file) nil "-type=build")))
           (if (eq return-code 0)
               (progn


### PR DESCRIPTION
Variables with names ending in -command are automatically marked as risky (see https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Local-Variables.html). This is appropriate as the buildifier command which is run could be any arbitrary executable.