### PR TITLE
Define syntax highlighting for bazel-mode keywords and built-ins

### DIFF
--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -73,17 +73,19 @@
   (when bazel-mode-buildifier-before-save
     (bazel-mode-buildifier)))
 
-(defconst bazel-mode--builtins
-  '("exports_files" "glob" "licenses" "package"
-    "package_group" "select" "workspace"))
-
-(defconst bazel-mode--keywords
-  '("and" "else" "for" "if" "in" "load" "not" "or"))
-
 (defconst bazel-mode--font-lock-defaults
-  `((
-     (,(regexp-opt bazel-mode--builtins 'symbols) . font-lock-builtin-face)
-     (,(regexp-opt bazel-mode--keywords 'symbols) . font-lock-keyword-face))))
+  `(
+    ;; Builtins for BUILD files are a subset of Starlark keywords. For details
+    ;; see https://docs.bazel.build/versions/master/skylark/language.html.
+    (,(regexp-opt '("exports_files" "glob" "licenses" "package"
+                    "package_group" "select" "workspace")
+                  'symbols)
+     . font-lock-builtin-face)
+    ;; Some Starlark functions are exposed to BUILD files as builtins. For
+    ;; details see https://github.com/bazelbuild/starlark/blob/master/spec.md.
+    (,(regexp-opt '("and" "else" "for" "if" "in" "load" "not" "or")
+                  'symbols)
+     . font-lock-keyword-face)))
 
 (defconst bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -101,7 +103,7 @@
   (setq-local comment-start-skip "#+")
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
-  (setq-local font-lock-defaults bazel-mode--font-lock-defaults)
+  (setq-local font-lock-defaults (list bazel-mode--font-lock-defaults))
   (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
             nil :local))
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -73,19 +73,19 @@
   (when bazel-mode-buildifier-before-save
     (bazel-mode-buildifier)))
 
-(defconst bazel-mode--font-lock-defaults
+(defconst bazel-mode--font-lock-keywords
   `(
-    ;; Builtins for BUILD files are a subset of Starlark keywords. For details
-    ;; see https://docs.bazel.build/versions/master/skylark/language.html.
+    ;; Some Starlark functions are exposed to BUILD files as builtins. For
+    ;; details see https://github.com/bazelbuild/starlark/blob/master/spec.md.
     (,(regexp-opt '("exports_files" "glob" "licenses" "package"
                     "package_group" "select" "workspace")
                   'symbols)
-     . font-lock-builtin-face)
-    ;; Some Starlark functions are exposed to BUILD files as builtins. For
-    ;; details see https://github.com/bazelbuild/starlark/blob/master/spec.md.
+     . 'font-lock-builtin-face)
+    ;; Keywords for BUILD files are a subset of Starlark keywords. For details
+    ;; see https://docs.bazel.build/versions/master/skylark/language.html.
     (,(regexp-opt '("and" "else" "for" "if" "in" "load" "not" "or")
                   'symbols)
-     . font-lock-keyword-face)))
+     . 'font-lock-keyword-face)))
 
 (defconst bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -103,7 +103,7 @@
   (setq-local comment-start-skip "#+")
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
-  (setq-local font-lock-defaults (list bazel-mode--font-lock-defaults))
+  (setq-local font-lock-defaults (list bazel-mode--font-lock-keywords))
   (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
             nil :local))
 

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -82,7 +82,7 @@
 
 (defconst bazel-mode--font-lock-defaults
   `((
-     (,(regexp-opt bazel-mode--builtins t) . font-lock-builtin-face)
+     (,(regexp-opt bazel-mode--builtins 'symbols) . font-lock-builtin-face)
      (,(regexp-opt bazel-mode--keywords 'symbols) . font-lock-keyword-face))))
 
 (defconst bazel-mode-syntax-table

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -73,6 +73,18 @@
   (when bazel-mode-buildifier-before-save
     (bazel-mode-buildifier)))
 
+(defconst bazel-mode--builtins
+  '("exports_files" "glob" "licenses" "package"
+    "package_group" "select" "workspace"))
+
+(defconst bazel-mode--keywords
+  '("and" "else" "for" "if" "in" "load" "not" "or"))
+
+(defconst bazel-mode--font-lock-defaults
+  `((
+     (,(regexp-opt bazel-mode--builtins t) . font-lock-builtin-face)
+     (,(regexp-opt bazel-mode--keywords 'symbols) . font-lock-keyword-face))))
+
 (defconst bazel-mode-syntax-table
   (let ((table (make-syntax-table)))
     ;; single line comment start
@@ -89,7 +101,7 @@
   (setq-local comment-start-skip "#+")
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
-  (setq-local font-lock-defaults '(nil))
+  (setq-local font-lock-defaults bazel-mode--font-lock-defaults)
   (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
             nil :local))
 


### PR DESCRIPTION
Defines syntax highlighting for BUILD files, which are a limited subset of Starlark (https://docs.bazel.build/versions/master/build-ref.html#BUILD_files). Specifically, we take Starlark keywords (https://github.com/bazelbuild/starlark/blob/master/spec.md#lexical-elements) and remove those which are disallowed from BUILD files. Builtins are taken from the Bazel build encyclopedia: https://docs.bazel.build/versions/master/be/overview.html. See https://docs.bazel.build/versions/master/skylark/language.html#differences-between-build-and-bzl-files for details. We do not treat the native rules (e.g. cc_library) as builtins, because these also have Starlark equivalents that may someday supersede the native rules.