### PR TITLE
Use Python indentation rules for Bazel mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bazel-emacs-bazel-mode
+/bazel-bin
+/bazel-out
+/bazel-testlogs

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sh_test(
+    name = "bazel_mode_test",
+    srcs = ["bazel-mode-test.sh"],
+    data = [
+        "BUILD",
+        "bazel-mode.el",
+        "bazel-mode-test.el",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "bazelbuild_emacs_bazel_mode")

--- a/bazel-mode-test.el
+++ b/bazel-mode-test.el
@@ -1,0 +1,42 @@
+;;; bazel-mode-test.el --- unit tests for bazel-mode.el  -*- lexical-binding: t; -*-
+
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;;; Commentary:
+
+;; Unit tests for bazel-mode.el.
+
+;;; Code:
+
+(require 'bazel-mode)
+
+(require 'ert)
+
+(ert-deftest bazel-mode/indent-after-colon ()
+  (with-temp-buffer
+    (bazel-mode)
+    (insert "def foo():")
+    (newline-and-indent)
+    (should (= (current-column) 4))))
+
+(ert-deftest bazel-mode/indent-region ()
+  (with-temp-buffer
+    (bazel-mode)
+    (insert-file-contents "BUILD")
+    (let ((before (buffer-string)))
+      (indent-region (point-min) (point-max))
+      (should (equal (buffer-string) before)))))
+
+;;; bazel-mode-test.el ends here

--- a/bazel-mode-test.sh
+++ b/bazel-mode-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"${EMACS:-emacs}" --quick --batch \
+  --directory="${PWD:?}" \
+  --load="${PWD:?}/bazel-mode-test.el" \
+  --funcall=ert-run-tests-batch-and-exit

--- a/bazel-mode.el
+++ b/bazel-mode.el
@@ -21,6 +21,8 @@
 ;;
 ;;; Code:
 
+(require 'python)
+
 (defgroup bazel-mode nil
   "Major mode for Bazel BUILD files."
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
@@ -119,6 +121,8 @@
   (setq-local comment-end "")
   (setq-local comment-use-syntax t)
   (setq-local font-lock-defaults (list bazel-mode--font-lock-keywords))
+  (setq-local indent-line-function #'python-indent-line-function)
+  (setq-local indent-region-function #'python-indent-region)
   (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
             nil :local))
 


### PR DESCRIPTION
The syntax of Python and Starlark should be identical as far as indentation is
concerned.

Also add a unit test.