### PR TITLE
Byte-compile source files.

### DIFF
--- a/lisp/BUILD
+++ b/lisp/BUILD
@@ -20,7 +20,18 @@ sh_test(
     srcs = ["bazel-mode-test.sh"],
     data = [
         "BUILD",
-        "bazel-mode.el",
-        "bazel-mode-test.el",
+        "bazel-mode.elc",
+        "bazel-mode-test.elc",
     ],
+)
+
+SRCS = glob(["*.el"])
+
+genrule(
+    name = "byte_compile",
+    srcs = SRCS,
+    outs = [src + "c" for src in SRCS],
+    cmd = ("$${EMACS:-emacs} --quick --batch --load=bytecomp --directory=$${PWD:?}/lisp " +
+           "--eval='(setq byte-compile-dest-file-function (lambda (src) (expand-file-name (concat (file-name-base src) \".elc\") \"$(RULEDIR)\")))' " +
+           "--funcall=batch-byte-compile $(SRCS)"),
 )

--- a/lisp/bazel-mode-test.sh
+++ b/lisp/bazel-mode-test.sh
@@ -16,5 +16,5 @@
 
 cd lisp && "${EMACS:-emacs}" --quick --batch \
   --directory="${PWD:?}" \
-  --load="${PWD:?}/bazel-mode-test.el" \
+  --load="${PWD:?}/bazel-mode-test.elc" \
   --funcall=ert-run-tests-batch-and-exit


### PR DESCRIPTION
This is useful because the byte compiler can find many issues in the code.