### PR TITLE
Enable compilation-minor-mode in the Buildifier error buffer.

### DIFF
--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -69,7 +69,8 @@
                 (kill-buffer buildifier-buffer))
             (with-temp-buffer-window
              buildifier-buffer nil nil
-             (insert-file-contents buildifier-error-file)))))
+             (insert-file-contents buildifier-error-file)
+             (compilation-minor-mode)))))
       (delete-file buildifier-input-file)
       (delete-file buildifier-error-file))))
 


### PR DESCRIPTION
This causes error messages to be clickable.