### PR TITLE
Improvements to Buildifier Flymake backend.

### DIFF
--- a/lisp/BUILD
+++ b/lisp/BUILD
@@ -22,6 +22,7 @@ sh_test(
         "BUILD",
         "bazel-mode.elc",
         "bazel-mode-test.elc",
+        "testdata/buildifier.bzl",
         "testdata/buildifier.json",
     ],
 )

--- a/lisp/bazel-mode-test.el
+++ b/lisp/bazel-mode-test.el
@@ -44,20 +44,34 @@
 We test that function instead of the Flymake backend directly so
 we don’t have to start or mock a process."
   (with-temp-buffer
-    (let ((output-buffer (current-buffer)))
-      ;; Example from
-      ;; https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#file-diagnostics-in-json.
+    (let ((output-buffer (current-buffer))
+          (diagnostics nil))
       (insert-file-contents "testdata/buildifier.json")
       (with-temp-buffer
-        ;; The exact contents of the input buffer don’t matter, but it should
-        ;; be large enough for the diagnostic to point to a valid position.
-        (insert "01234567890123456789\n")
-        (should (equal (bazel-mode--make-diagnostics output-buffer)
-                       (list (flymake-make-diagnostic
-                              (current-buffer) 6 11 :warning
-                              (concat "The \"/\" operator for integer division "
-                                      "is deprecated in favor of \"//\". "
-                                      "[integer-division] "
-                                      "(https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)")))))))))
+        (insert-file-contents "testdata/buildifier.bzl")
+        (dolist (diag (bazel-mode--make-diagnostics output-buffer))
+          (ert-info ((prin1-to-string diag))
+            (should (eq (flymake-diagnostic-buffer diag) (current-buffer)))
+            (should (eq (flymake-diagnostic-type diag) :warning))
+            (push (list (buffer-substring-no-properties
+                         (flymake-diagnostic-beg diag)
+                         (flymake-diagnostic-end diag))
+                        (flymake-diagnostic-text diag))
+                  diagnostics))))
+      (should (equal (nreverse diagnostics)
+                     `(("def foo(bar):"
+                        ,(concat "The file has no module docstring. "
+                                 "[module-docstring] "
+                                 "(https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring)"))
+                       ("\"\"\" \"\"\""
+                        ,(concat "The docstring for the function \"foo\" "
+                                 "should start with a one-line summary. "
+                                 "[function-docstring-header] "
+                                 "(https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#function-docstring-header)"))
+                       ("1 / 2"
+                        ,(concat "The \"/\" operator for integer division "
+                                 "is deprecated in favor of \"//\". "
+                                 "[integer-division] "
+                                 "(https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division)"))))))))
 
 ;;; bazel-mode-test.el ends here

--- a/lisp/testdata/buildifier.bzl
+++ b/lisp/testdata/buildifier.bzl
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def foo(bar):
+    """ """
+    a = 1 / 2
+
+# Run “make_buildifier_json” to regenerate buildifier.json.

--- a/lisp/testdata/buildifier.json
+++ b/lisp/testdata/buildifier.json
@@ -2,18 +2,46 @@
     "success": false,
     "files": [
         {
-            "filename": "file_1.bzl",
+            "filename": "buildifier.bzl",
             "formatted": true,
             "valid": true,
             "warnings": [
                 {
                     "start": {
-                        "line": 1,
+                        "line": 15,
+                        "column": 1
+                    },
+                    "end": {
+                        "line": 15,
+                        "column": 2
+                    },
+                    "category": "module-docstring",
+                    "actionable": true,
+                    "message": "The file has no module docstring.\nA module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines).",
+                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring"
+                },
+                {
+                    "start": {
+                        "line": 16,
                         "column": 5
                     },
                     "end": {
-                        "line": 1,
-                        "column": 10
+                        "line": 16,
+                        "column": 12
+                    },
+                    "category": "function-docstring-header",
+                    "actionable": true,
+                    "message": "The docstring for the function \"foo\" should start with a one-line summary.",
+                    "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#function-docstring-header"
+                },
+                {
+                    "start": {
+                        "line": 17,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 14
                     },
                     "category": "integer-division",
                     "actionable": true,
@@ -21,27 +49,6 @@
                     "url": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#integer-division"
                 }
             ]
-        },
-        {
-            "filename": "file_2.bzl",
-            "formatted": false,
-            "valid": true,
-            "warnings": [],
-            "rewrites": {
-                "editoctal": 1
-            }
-        },
-        {
-            "filename": "file_3.bzl",
-            "formatted": true,
-            "valid": true,
-            "warnings": []
-        },
-        {
-            "filename": "file_4.not_bzl",
-            "formatted": false,
-            "valid": false,
-            "warnings": []
         }
     ]
 }

--- a/lisp/testdata/make_buildifier_json
+++ b/lisp/testdata/make_buildifier_json
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+buildifier -mode=check -lint=warn -format=json -v -- buildifier.bzl > buildifier.json


### PR DESCRIPTION
- Fix off-by-one error when counting columns.

- Correctly deal with overflow in lines and columns independently.

- Add a heuristic to detect warnings that span an entire line.

- Abbreviate message.

- Use a more realistic example for testing.

- Add a script to regenerate the test data.

- Simplify test to compare the buffer text instead of the (not very meaningful)
  buffer positions.