### PR TITLE
Add an XRef backend for ‘bazel-mode’.

### DIFF
--- a/lisp/BUILD
+++ b/lisp/BUILD
@@ -25,6 +25,7 @@ sh_test(
         "bazel-util.elc",
         "testdata/buildifier.bzl",
         "testdata/buildifier.json",
+        "testdata/xref.BUILD",
     ],
 )
 

--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -21,10 +21,13 @@
 ;;
 ;;; Code:
 
+(require 'cl-lib)
 (require 'flymake)
 (require 'json)
+(require 'pcase)
 (require 'python)
 (require 'rx)
+(require 'xref)
 
 (require 'bazel-util)
 
@@ -134,7 +137,8 @@
   (setq-local indent-region-function #'python-indent-region)
   (add-hook 'before-save-hook #'bazel-mode--buildifier-before-save-hook
             nil :local)
-  (add-hook 'flymake-diagnostic-functions #'bazel-mode-flymake nil :local))
+  (add-hook 'flymake-diagnostic-functions #'bazel-mode-flymake nil :local)
+  (add-hook 'xref-backend-functions #'bazel-mode-xref-backend nil :local))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist
@@ -275,6 +279,236 @@ https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#file-d
                                               (string-match-p (rx ?\n) message))
                      (gethash "category" warning)
                      (gethash "url" warning)))))
+
+;;; XRef backend
+
+;; This backend is optimized for speed, not correctness.  This means that we
+;; use heuristics to find BUILD files and targets.  In particular, we assume
+;; that if a target looks like it refers to a file and the file exists, it
+;; actually refers to that file.
+
+(defun bazel-mode-xref-backend ()
+  "XRef backend function for ‘bazel-mode’.
+This gets added to ‘xref-backend-functions’."
+  (and (derived-mode-p 'bazel-mode)
+       buffer-file-name
+       ;; It only makes sense to find targets if we are in a workspace,
+       ;; otherwise we don’t know how to resolve absolute labels.
+       (bazel-util-workspace-root buffer-file-name)
+       'bazel-mode))
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql bazel-mode)))
+  ;; This only detects string literals representing labels.
+  (let ((identifier (bazel-mode--string-at-point)))
+    (when identifier
+      ;; Save the current workspace directory and package as text properties
+      ;; in case the user switches directories between this call and
+      ;; selecting a reference.  ‘xref-backend-definitions’ falls back to the
+      ;; current workspace and package if these properties aren’t present so
+      ;; that users can still invoke ‘xref-find-definitions’ and enter a
+      ;; label manually.  We don’t care about valid but exotic labels here,
+      ;; e.g., labels containing newlines or backslashes.
+      (let* ((workspace
+              (and buffer-file-name
+                   (bazel-util-workspace-root buffer-file-name)))
+             (package
+              (and workspace
+                   (bazel-util-package-name buffer-file-name workspace))))
+        (propertize identifier
+                    'bazel-mode-workspace workspace
+                    'bazel-mode-package package)))))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql bazel-mode)) identifier)
+  (cl-destructuring-bind (&whole valid-p &optional workspace package target)
+      (bazel-mode--parse-label identifier)
+    (when valid-p
+      (let* ((this-workspace
+              (or (get-text-property 0 'bazel-workspace-mode identifier)
+                  (and buffer-file-name
+                       (bazel-util-workspace-root buffer-file-name))))
+             (package
+              (or package
+                  (get-text-property 0 'bazel-mode-package identifier)
+                  (and buffer-file-name this-workspace
+                       (bazel-util-package-name buffer-file-name
+                                                this-workspace)))))
+        (when (and this-workspace package)
+          (let* ((workspace-root
+                  (bazel-mode--external-workspace workspace this-workspace))
+                 (directory (expand-file-name package workspace-root))
+                 (filename (expand-file-name target directory))
+                 (location
+                  (if (file-exists-p filename)
+                      ;; A label that likely refers to a source file.
+                      (bazel-mode--file-location filename)
+                    ;; A label that likely refers to a rule.  Try to find the
+                    ;; rule in the BUILD file of the package.
+                    (let ((build-file
+                           (locate-file "BUILD" (list directory) '("" ".bazel"))))
+                      (when build-file
+                        (bazel-mode--rule-location build-file target))))))
+            (when location
+              (list (xref-make (bazel-mode--canonical workspace package target)
+                               location)))))))))
+
+(defun bazel-mode--file-location (filename)
+  "Return an ‘xref-location’ for the source file FILENAME."
+  (cl-check-type filename string)
+  (let ((buffer (find-buffer-visiting filename)))
+    (if buffer
+        ;; The location actually refers to the whole file.  Avoid jumping
+        ;; around within the already-visited file by pretending the reference
+        ;; is at point.
+        (xref-make-buffer-location buffer (with-current-buffer buffer (point)))
+      ;; File not yet visited; beginning of the file is fine.
+      (xref-make-file-location filename 1 0))))
+
+(defun bazel-mode--rule-location (build-file name)
+  "Return an ‘xref-location’ for a rule within a BUILD file.
+The name of the BUILD file is BUILD-FILE, and NAME is the local
+name of the rule.  If NAME doesn’t seem to exist in BUILD-FILE,
+return a location referring to an arbitrary position within the
+BUILD file."
+  (cl-check-type build-file string)
+  (cl-check-type name string)
+  (let ((buffer (find-buffer-visiting build-file)))
+    ;; Reuse a buffer that already visits the BUILD file if possible.
+    (if buffer
+        (with-current-buffer buffer
+          (xref-make-buffer-location buffer (bazel-mode--find-rule name)))
+      (with-temp-buffer
+        (insert-file-contents build-file)
+        (goto-char (bazel-mode--find-rule name))
+        (xref-make-file-location build-file
+                                 (line-number-at-pos)
+                                 (- (point) (line-beginning-position)))))))
+
+(defun bazel-mode--find-rule (name)
+  "Find the rule with the given NAME within the current buffer.
+The current buffer should visit a BUILD file.  If there’s a rule
+with the given NAME, return the location of the rule.  Otherwise,
+return point."
+  (cl-check-type name string)
+  (let ((case-fold-search nil))
+    (or (save-excursion
+          (save-restriction
+            (widen)
+            (goto-char (point-min))
+            ;; Heuristic: we search for a “name” attribute as it would show up
+            ;; in typical BUILD files.  That’s not 100% correct, but doesn’t
+            ;; rely on external processes and should work fine in common cases.
+            (when (re-search-forward
+                   (rx-to-string
+                    `(seq bol (* blank) "name" (* blank) ?= (* blank)
+                          (group (any ?\" ?')) (group ,name) (backref 1)))
+                   nil t)
+              (match-beginning 2))))
+        (point))))
+
+;;; Utilities
+
+(defun bazel-mode--external-workspace (workspace-name this-workspace-root)
+  "Return the workspace root of an external workspace.
+WORKSPACE-NAME should be either a string naming an external
+workspace, or nil to refer to the current workspace.
+THIS-WORKSPACE-ROOT should be the name of the current workspace
+root directory, as returned by ‘bazel-util-workspace-root’.  The
+return value is a directory name."
+  (cl-check-type workspace-name (or null string))
+  (cl-check-type this-workspace-root string)
+  (file-name-as-directory
+   (if workspace-name
+       ;; See https://docs.bazel.build/versions/2.0.0/output_directories.html
+       ;; for some overview of the Bazel directory layout.  Empirically, the
+       ;; directory ROOT/bazel-ROOT/external/WORKSPACE is a symlink to the
+       ;; workspace root of the external workspace WORKSPACE.  Again, this is a
+       ;; heuristic, and should work for the common case.  In particular, we
+       ;; don’t want to shell out to “bazel info workspace” here, because that
+       ;; might block indefinitely if another Bazel instance holds the lock.
+       ;; We don’t check whether the directory exists, because it’s generated
+       ;; and cached when needed.
+       (expand-file-name (concat "bazel-"
+                                 (file-name-nondirectory
+                                  (directory-file-name this-workspace-root))
+                                 "/external/" workspace-name)
+                         this-workspace-root)
+     this-workspace-root)))
+
+(defun bazel-mode--parse-label (label)
+  "Parse Bazel label LABEL.
+If LABEL isn’t syntactically valid, return nil.  Otherwise,
+return a triple (WORKSPACE PACKAGE TARGET).  WORKSPACE is
+nil (for the current workspace) or a string referring to some
+external workspace.  PACKAGE is nil (for the current package) or
+a package name string.  TARGET is a string referring to the local
+name of LABEL.  See
+https://docs.bazel.build/versions/2.0.0/build-ref.html#lexi for
+the lexical syntax of labels."
+  (cl-check-type label string)
+  (pcase (substring-no-properties label)
+    ((rx bos
+         (or
+          ;; @workspace//package:target
+          (seq "@" (let workspace (+ (not (any ?: ?/))))
+               "//" (let package (* (not (any ?:))))
+               ?: (let target (+ (not (any ?:)))))
+          ;; @workspace//package
+          (seq "@" (let workspace (+ (not (any ?: ?/))))
+               "//" (let package (+ (not (any ?:)))))
+          ;; //package:target
+          (seq "//" (let package (* (not (any ?:))))
+               ?: (let target (+ (not (any ?:)))))
+          ;; //package
+          (seq "//" (let package (+ (not (any ?:)))))
+          ;; :target
+          (seq ?: (let target (+ (not (any ?:)))))
+          ;; target
+          (seq (let target (+ (not (any ?:))))))
+         eos)
+     (unless target (setq target (bazel-mode--default-target package)))
+     (and (or (null workspace)
+              (string-match-p (rx bos (+ (any ?- "A-Za-z0-9.")) eos) workspace))
+          (or (null package)
+              ;; https://docs.bazel.build/versions/2.0.0/build-ref.html#package-names-package-name
+              (string-match-p (rx bos (* (any ?- "A-Za-z0-9/.")) eos) package))
+          ;; https://docs.bazel.build/versions/2.0.0/build-ref.html#package-names-package-name
+          (string-match-p (rx bos
+                              (+ (any ?- "a-zA-Z0-9!%-@^_` \"#$&'()*+,;<=>"
+                                      "?[]{|}~/."))
+                              eos)
+                          target)
+          (list workspace package target)))))
+
+(defun bazel-mode--default-target (package)
+  "Return the default target name for PACKAGE.
+For a package “foo/bar”, “bar” is the default target."
+  (cl-check-type package string)
+  ;; There’s no function to search backwards within a string, so we reverse the
+  ;; string twice.
+  (let ((reversed (reverse package)))
+    (nreverse (substring-no-properties reversed nil
+                                       (string-match-p reversed (rx ?/))))))
+
+(defun bazel-mode--canonical (workspace package target)
+  "Return a canonical label.
+WORKSPACE is either nil (referring to the current workspace) or
+an external workspace name.  PACKAGE and TARGET should both be
+strings.  Return either @WORKSPACE//PACKAGE:TARGET or
+//PACKAGE:TARGET."
+  (cl-check-type workspace (or null string))
+  (cl-check-type package string)
+  (cl-check-type target string)
+  (concat (and workspace (concat "@" workspace)) "//" package ":" target))
+
+(defun bazel-mode--string-at-point ()
+  "Return the string literal at point, or nil if not inside a string literal."
+  (let ((state (syntax-ppss)))
+    (when (nth 3 state)  ; in string
+      (let ((start (1+ (nth 8 state))))  ; (nth 8 state) is the opening quote
+        (save-excursion
+          ;; Jump to the closing quotation mark.
+          (parse-partial-sexp (point) (point-max) nil nil state 'syntax-table)
+          (buffer-substring-no-properties start (1- (point))))))))
 
 (defun bazel-mode--line-column-pos (line column)
   "Return buffer position in the current buffer for LINE and COLUMN.

--- a/lisp/testdata/xref.BUILD
+++ b/lisp/testdata/xref.BUILD
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "lib",
+    srcs = [
+        "aaa.cc",
+        "dir/bbb.cc",
+        ":aaa.cc",
+        "//:aaa.cc",
+        "//pkg:ccc.cc",
+        "@ws//pkg:ddd.cc",
+    ],
+)
+
+cc_binary(
+    name = "bin",
+    deps = [
+        ":lib",
+        "//:lib",
+        "//pkg",
+        "//pkg:lib",
+    ],
+)


### PR DESCRIPTION
Right now this only allows jumping to a target, either a source file or a rule.