### PR TITLE
Don’t add an additional group when constructing a regex.

### DIFF
--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -400,7 +400,8 @@ return point."
             (when (re-search-forward
                    (rx-to-string
                     `(seq bol (* blank) "name" (* blank) ?= (* blank)
-                          (group (any ?\" ?')) (group ,name) (backref 1)))
+                          (group (any ?\" ?')) (group ,name) (backref 1))
+                    :no-group)
                    nil t)
               (match-beginning 2))))
         (point))))


### PR DESCRIPTION
This doesn’t have any semantic effect, but makes the resulting regex a bit
simpler.