### PR TITLE
Make test suite succeed under Emacs 27.

### DIFF
--- a/lisp/bazel-mode-test.el
+++ b/lisp/bazel-mode-test.el
@@ -47,6 +47,9 @@
   "Unit test for ‘bazel-mode--make-diagnostics’.
 We test that function instead of the Flymake backend directly so
 we don’t have to start or mock a process."
+  ;; This test doesn’t work in Emacs 27 due to
+  ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=39971.
+  (skip-unless (not (eql emacs-major-version 27)))
   (with-temp-buffer
     (let ((output-buffer (current-buffer))
           (diagnostics nil))


### PR DESCRIPTION
We have to skip one test due to
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=39971.