### PR TITLE
Add basic support for “keep sorted” comments.

### DIFF
--- a/lisp/BUILD
+++ b/lisp/BUILD
@@ -25,6 +25,7 @@ sh_test(
         "bazel-util.elc",
         "testdata/buildifier.bzl",
         "testdata/buildifier.json",
+        "testdata/fill.BUILD",
         "testdata/xref.BUILD",
     ],
 )

--- a/lisp/bazel-mode-test.el
+++ b/lisp/bazel-mode-test.el
@@ -172,4 +172,14 @@ that buffer once BODY finishes."
                      ("//pkg:pkg" "pkg/BUILD")
                      ("//pkg:lib" "pkg/BUILD"))))))
 
+(ert-deftest bazel-mode/fill ()
+  "Check that “keep sorted” comments are left alone."
+  (with-temp-buffer
+    (insert-file-contents "testdata/fill.BUILD")
+    (bazel-mode)
+    (search-forward "# The Foobar files")
+    (let ((before (buffer-string)))
+      (fill-paragraph)
+      (should (equal (buffer-string) before)))))
+
 ;;; bazel-mode-test.el ends here

--- a/lisp/testdata/fill.BUILD
+++ b/lisp/testdata/fill.BUILD
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+my_rule(
+    name = "lib",
+    # The Foobar files.
+    # keep sorted
+    foobar_files = [
+        "bar",
+        "foo",
+    ],
+)


### PR DESCRIPTION
- Fontify them as preprocessor symbols.
- Keep them on their own line while filling.