### PR TITLE
Add front-matter for MELPA compatibility.

### DIFF
--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -1,5 +1,9 @@
 ;;; bazel-mode.el --- Emacs major mode for editing Bazel BUILD and WORKSPACE files -*- lexical-binding: t; -*-
 
+;; URL: https://github.com/bazelbuild/emacs-bazel-mode
+;; Keywords: build tools, languages
+;; Package-Requires: ((emacs "26.1"))
+;; Version: 0
 
 ;; Copyright (C) 2018 Google LLC
 ;; Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
MELPA, a popular Emacs package index, needs some additional metadata in
the header. Including 'Version: 0' is enough to silence the linter, and
this does not need to be updated unless the author(s) wish to publish
on MELPA stable: https://stable.melpa.org

This commit has been broken off of #53 as requested.