### PR TITLE
Don’t allow starting package names with a period.

### DIFF
--- a/lisp/bazel-util.el
+++ b/lisp/bazel-util.el
@@ -49,6 +49,7 @@ If FILE-NAME is not in a Bazel package, return nil."
              (and package-name
                   (not (file-remote-p package-name))
                   (not (file-name-absolute-p package-name))
+                  (not (string-prefix-p "." package-name))
                   (directory-file-name package-name)))))))
 
 (provide 'bazel-util)


### PR DESCRIPTION
This is in theory possible, if the package name resolution resulted in a
directory above the workspace root.