### PR TITLE
Small fixes for section headings.

### DIFF
--- a/lisp/bazel-build.el
+++ b/lisp/bazel-build.el
@@ -1,5 +1,5 @@
 ;;; bazel-build.el --- Emacs utilities for using Bazel -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2018 Google LLC
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-;;
+
 ;;; Commentary:
-;;
+
 ;; This package provides commands to build and run code using Bazel.
 ;; It defines interactive commands which perform completion of available Bazel
 ;; targets:
 ;;   - `bazel-build'
 ;;   - `bazel-run'
 ;;   - `bazel-test'
-;;
+
 ;;; Code:
 
 (require 'bazel-util)

--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -17,12 +17,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-;;
+
 ;;; Commentary:
-;;
+
 ;; This package provides Emacs bazel-mode, a major mode for editing Bazel
 ;; BUILD and WORKSPACE files.
-;;
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -216,7 +216,7 @@ This is the parent mode for the more specific modes
              ;; https://docs.bazel.build/versions/3.0.0/skylark/concepts.html#getting-started
              (cons (rx ?/ (+ nonl) ".bzl" eos) #'bazel-starlark-mode))
 
-;;; Flymake support using Buildifier
+;;;; Flymake support using Buildifier
 
 (defvar-local bazel-mode--flymake-process nil
   "Current Buildifier process for this buffer.
@@ -366,7 +366,7 @@ https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#file-d
                      (gethash "category" warning)
                      (gethash "url" warning)))))
 
-;;; XRef backend
+;;;; XRef backend
 
 ;; This backend is optimized for speed, not correctness.  This means that we
 ;; use heuristics to find BUILD files and targets.  In particular, we assume
@@ -597,7 +597,7 @@ This gets added to ‘ffap-alist’."
              (file-missing nil))))
       (locate-file filename (cons main-root external-roots)))))
 
-;;; Utilities
+;;;; Utilities
 
 (defun bazel-mode--external-workspace (workspace-name this-workspace-root)
   "Return the workspace root of an external workspace.


### PR DESCRIPTION
- Use four semicolons for subsections of the code; see
  https://www.gnu.org/software/emacs/manual/html_node/elisp/Comment-Tips.html.

- Remove empty comments around headings to make them stand out more.