### PR TITLE
Open .BUILD files in bazel-build-mode

### DIFF
--- a/lisp/bazel-mode.el
+++ b/lisp/bazel-mode.el
@@ -191,6 +191,7 @@ This is the parent mode for the more specific modes
 (add-to-list 'auto-mode-alist
              ;; https://docs.bazel.build/versions/3.0.0/build-ref.html#packages
              (cons (rx ?/ (or "BUILD" "BUILD.bazel") eos) #'bazel-build-mode))
+(add-to-list 'auto-mode-alist '("\\.BUILD\\'" . bazel-build-mode))
 
 ;;;###autoload
 (define-derived-mode bazel-workspace-mode bazel-mode "Bazel WORKSPACE"


### PR DESCRIPTION
My work uses this convention where we put the build files for third-party vendored libs into a single directory that has a bunch of files named things like `nameofdep.BUILD`. I've seen this convention used in other bazel repos as well, notably this is the same convention that Envoy uses: https://github.com/envoyproxy/envoy/tree/master/bazel/external

The way I've implemented this (by pushing another item to the auto-mode-alist) probably isn't right, it would be better to update the rx expression on the line above. But I don't really grok how to use rx, so if you want to close this PR and update the rx expression that would also make me happy.