### PR TITLE
Use bazel query to provide completion on target names

### DIFF
--- a/lisp/bazel-util.el
+++ b/lisp/bazel-util.el
@@ -27,7 +27,8 @@
 If FILE-NAME is not in a Bazel workspace, return nil.  Otherwise,
 the return value is a directory name."
   (cl-check-type file-name string)
-  (let ((result (locate-dominating-file file-name "WORKSPACE")))
+  (let ((result (or (locate-dominating-file file-name "WORKSPACE")
+                    (locate-dominating-file file-name "WORKSPACE.bazel"))))
     (and result (file-name-as-directory result))))
 
 (defun bazel-util-package-name (file-name workspace-root)


### PR DESCRIPTION
This CL enhances the build commands by automatically inferring the name of the target from the current buffer. If multiple targets match, completion is provided with the list.

This also changes the commands to run from the root of the workspace with a cd <rootdir> before the command name. There's an option to turn that behavior on. I think this is the most natural way to work with bazel (cwd at root of workspace).

If the current buffer is
- A file, bazel query is used to figure out the name of the target that the file is a src of.
- A directory (dired mode), the list of targets in the package is provided with default :all
- A BUILD file, the targets in the package as well.

Note that I did not add unit tests. I did check locally on all three files that it works. This PR for your consideration. I'll be running this on my box for a while. Happy to move to a branch if you prefer to work that way (let me know0.

Some further improvements are possible for the future:
- Adding an option to disable this might be useful, as it can be a little slow.
- When computing the completion list over a file, it may be a good idea to actually fetch it for the enclosing package, so that if the user wants to edit it there's completion from packages nearby.
- If a single target matches the file, maybe the command should just run. Using a prefix argument to allow the user to edit the target before running, perhaps.
