### PR TITLE
Strip properties from identifier.

### DIFF
--- a/lisp/bazel-mode-test.el
+++ b/lisp/bazel-mode-test.el
@@ -175,7 +175,8 @@ that buffer once BODY finishes."
                       ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=29579.
                       (cl-callf file-name-unquote root)
                       (cl-callf file-name-unquote ref-file))
-                    (push (list identifier (file-relative-name ref-file root))
+                    (push (list (substring-no-properties identifier)
+                                (file-relative-name ref-file root))
                           definitions)))))))
         ;; Test completions.
         (should


### PR DESCRIPTION
This isn’t strictly needed (the ‘equal’ below ignores properties when comparing
strings), but reduces clutter in the structural difference, if there is one.