### PR TITLE
Save current buffer when jumping to error locations.

### DIFF
--- a/lisp/bazel-mode-test.el
+++ b/lisp/bazel-mode-test.el
@@ -293,7 +293,7 @@ the rule."
           (should (looking-at-p
                    (rx bol "WARNING: " (+ nonl) "/package/BUILD:15:1: target "
                        "'//package:test' is deprecated: Deprecated!" eol)))
-          (compile-goto-error)
+          (save-current-buffer (compile-goto-error))
           (should (equal file (file-name-unquote
                                (expand-file-name "package/BUILD" dir))))
           (should (equal line "cc_library(")))
@@ -302,13 +302,13 @@ the rule."
           (should (looking-at-p
                    (rx bol "ERROR: " (+ nonl) "/package/BUILD:15:1: "
                        "C++ compilation")))
-          (compile-goto-error)
+          (save-current-buffer (compile-goto-error))
           (should (equal file (file-name-unquote
                                (expand-file-name "package/BUILD" dir))))
           (should (equal line "cc_library(")))
         (ert-info ("Compiler error")
           (compilation-next-error 1)
-          (compile-goto-error)
+          (save-current-buffer (compile-goto-error))
           (should (equal file (file-name-unquote
                                (expand-file-name "package/test.cc" dir))))
           (should (equal line "UnknownType foo;")))


### PR DESCRIPTION
Emacs 26 used to accept the test without this, but with Emacs 27 we need to be
more careful to stay in the right buffer.