### PR TITLE
Remove unnecessary ‘bazel-mode-’ prefixes from public symbols.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -52,18 +52,25 @@
 (require 'xref)
 
 (defgroup bazel nil
-  "Major mode for Bazel BUILD files."
+  "Package for editing, building, and running code using Bazel."
+  :link '(url-link "https://bazel.build")
   :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
   :group 'languages)
 
-(defcustom bazel-mode-buildifier-command "buildifier"
+(define-obsolete-variable-alias 'bazel-mode-buildifier-command
+  'bazel-buildifier-command "2021-04-13")
+
+(defcustom bazel-buildifier-command "buildifier"
   "Filename of buildifier executable."
   :type 'file
   :group 'bazel
   :link '(url-link
           "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))
 
-(defcustom bazel-mode-buildifier-before-save nil
+(define-obsolete-variable-alias 'bazel-mode-buildifier-before-save
+  'bazel-buildififer-before-save "2021-04-13")
+
+(defcustom bazel-buildifier-before-save nil
   "Specifies whether to run buildifer in `before-save-hook'."
   :type 'boolean
   :group 'bazel
@@ -78,7 +85,7 @@ flag.  See
 https://github.com/bazelbuild/buildtools/blob/2.2.0/buildifier/utils/flags.go#L11.
 If nil, don’t pass a -type flag to Buildifier.")
 
-(defun bazel-mode-buildifier ()
+(defun bazel-buildifier ()
   "Format current buffer using buildifier."
   (interactive "*")
   (let ((input-buffer (current-buffer))
@@ -110,10 +117,13 @@ If nil, don’t pass a -type flag to Buildifier.")
       (delete-file buildifier-input-file)
       (delete-file buildifier-error-file))))
 
+(define-obsolete-function-alias 'bazel-mode-buildifier
+  #'bazel-buildifier "2021-04-13")
+
 (defun bazel-mode--buildifier-before-save-hook ()
   "Run buildifer in `before-save-hook'."
   (when bazel-mode-buildifier-before-save
-    (bazel-mode-buildifier)))
+    (bazel-buildifier)))
 
 (defconst bazel-mode--font-lock-keywords
   `(
@@ -879,17 +889,14 @@ Look for an imported file with the given NAME."
 
 ;;;; Commands to build and run code using Bazel
 
-(defgroup bazel-build nil
-  "Package for editing, building, and running code using Bazel."
-  :link '(url-link "https://bazel.build")
-  :link '(url-link "https://github.com/bazelbuild/emacs-bazel-mode")
-  :group 'languages)
+(define-obsolete-variable-alias 'bazel-build-bazel-command
+  'bazel-command "2021-04-13")
 
-(defcustom bazel-build-bazel-command '("bazel")
+(defcustom bazel-command '("bazel")
   "Command and arguments that should be used to invoke Bazel."
   :type '(repeat string)
   :risky t
-  :group 'bazel-build)
+  :group 'bazel)
 
 (defun bazel-build (target)
   "Build a Bazel TARGET."

--- a/test.el
+++ b/test.el
@@ -99,13 +99,13 @@ we don’t have to start or mock a process."
 (ert-deftest bazel-mode-flymake ()
   "Unit test for the ‘bazel-mode-flymake’ Flymake backend."
   (with-temp-buffer
-    (let ((bazel-mode-buildifier-command
+    (let ((bazel-buildifier-command
            (expand-file-name "testdata/fake_buildifier"
                              bazel-mode-test--directory))
           (flymake-diagnostic-functions '(bazel-mode-flymake))
           (warning-minimum-log-level :debug)
           (diagnostics ()))
-      (skip-unless (file-executable-p bazel-mode-buildifier-command))
+      (skip-unless (file-executable-p bazel-buildifier-command))
       (insert-file-contents
        (expand-file-name "testdata/buildifier.bzl" bazel-mode-test--directory))
       (flymake-mode)


### PR DESCRIPTION
Now that all the code is in a single file, we don’t need to prefix everything
with ‘bazel-mode’ any more.  Remove the ‘mode’ part from a few symbols that
aren’t closely associated with ‘bazel-mode’ itself.  Add obsolete aliases for
them.  Also merge the two customization groups into a single one.