### PR TITLE
Add support for displaying coverage information.

### DIFF
--- a/testdata/coverage.BUILD
+++ b/testdata/coverage.BUILD
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "library",
+    hdrs = ["library.h"],
+)
+
+cc_test(
+    name = "library_test",
+    srcs = ["library_test.cc"],
+    deps = [":library"],
+)

--- a/testdata/coverage.dat
+++ b/testdata/coverage.dat
@@ -1,0 +1,12 @@
+SF:package/library.h
+FN:15,_Z8Functionb
+FNDA:1,_Z8Functionb
+FNF:1
+FNH:1
+DA:15,1
+DA:16,1
+DA:17,1
+DA:19,0
+LH:3
+LF:4
+end_of_record

--- a/testdata/coverage.out
+++ b/testdata/coverage.out
@@ -1,0 +1,26 @@
+Loading: 
+Loading: 0 packages loaded
+INFO: Using default value for --instrumentation_filter: "^//package[/:]".
+INFO: Override the above default with --instrumentation_filter
+Analyzing: 2 targets (1 packages loaded, 0 targets configured)
+Analyzing: 2 targets (12 packages loaded, 18 targets configured)
+Analyzing: 2 targets (23 packages loaded, 309 targets configured)
+Analyzing: 2 targets (24 packages loaded, 358 targets configured)
+Analyzing: 2 targets (24 packages loaded, 358 targets configured)
+INFO: Analyzed 2 targets (25 packages loaded, 508 targets configured).
+INFO: Found 1 target and 1 test target...
+bazel: Entering directory `%EXECROOT%/'
+[0 / 8] [Prepa] Writing file package/library/baseline_coverage.dat ... (5 actions, 0 running)
+[12 / 16] [Prepa] Action external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class
+[13 / 16] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 0s linux-sandbox
+[14 / 16] [Prepa] Building external/remote_coverage_tools/Main.jar ()
+bazel: Leaving directory `%EXECROOT%/'
+INFO: Elapsed time: 10.861s, Critical Path: 3.95s
+INFO: 16 processes: 9 internal, 6 linux-sandbox, 1 worker.
+INFO: Build completed successfully, 16 total actions
+//package:library_test                                                   PASSED in 0.5s
+  %EXECROOT%/bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat
+
+Executed 1 out of 1 test: 1 test passes.
+There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
+INFO: Build completed successfully, 16 total actions

--- a/testdata/library.h
+++ b/testdata/library.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+inline int Function(bool arg) {
+  if (arg) {
+    return 137;
+  } else {
+    return 42;
+  }
+}

--- a/testdata/library_test.cc
+++ b/testdata/library_test.cc
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+
+#include "library.h"
+
+int main() {
+  return Function(true) == 137 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run this script to regenerate coverage.out and coverage.dat.
+
+set -eu
+
+# Bazel formats output differently when invoked from Emacs.
+export INSIDE_EMACS='27.2,compile'
+
+workspace="$(bazel info workspace)" || exit
+testdata="${workspace:?}/testdata"
+
+dir="$(mktemp --directory)" || exit
+trap 'rm --recursive --force -- "${dir}"' EXIT
+
+# Set up a basic workspace layout in the temporary directory.
+cp --no-target-directory -- "${testdata:?}/test.WORKSPACE" "${dir:?}/WORKSPACE"
+mkdir -- "${dir:?}/package" || exit
+cp --no-target-directory -- \
+  "${testdata:?}/coverage.BUILD" "${dir:?}/package/BUILD" || exit
+cp --target-directory="${dir:?}/package" -- \
+  "${testdata:?}/library.h" "${testdata:?}/library_test.cc" || exit
+
+execroot="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info execution_root)"
+
+# We explicitly compile with the current directory set to a subdirectory to
+# ensure that workspace-relative filenames still work as expected.
+out="$(cd "${dir:?}/package" && bazel --bazelrc=/dev/null coverage //... 2>&1)"
+
+# Parse output to find location of coverage.dat.  The output should be
+# relatively stable,
+# cf. https://docs.bazel.build/versions/4.0.0/guide.html#parsing-output.
+pattern=$'\n''  (/.+/coverage\.dat)'$'\n'
+[[ "${out:?}" =~ ${pattern:?} ]] || exit
+dat="${BASH_REMATCH[1]}"
+cp --no-target-directory -- "${dat:?}" "${testdata:?}/coverage.dat" || exit
+
+# Replace the execution root in the output with a placeholder.
+out="${out//${execroot}/%EXECROOT%}"
+
+echo "${out:?}" > "${testdata:?}/coverage.out"
+
+echo 'Successfully generated coverage.out and coverage.dat.'


### PR DESCRIPTION
Parse Bazel output for coverage instrumentation files.  When such files are
found, attempt to display the coverage information in buffers that visit the
respective files.