### PR TITLE
Use a quoted list for ‘compilation-error-regexp-alist-alist’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -688,7 +688,7 @@ the message type, as in ‘compilation-error-regexp-alist’."
       `(progn
          (add-to-list 'compilation-error-regexp-alist ',name)
          (add-to-list 'compilation-error-regexp-alist-alist
-                      (list ',name ,regexp 1 2 3 ,type))))))
+                      '(,name ,regexp 1 2 3 ,type))))))
 
 (bazel--add-compilation-error-regexp bazel-mode-info "INFO" 0)
 (bazel--add-compilation-error-regexp bazel-mode-warning "WARNING" 1)


### PR DESCRIPTION
No semantic difference, but this is a bit less code.