### PR TITLE
Broaden buildifier magic comment detection

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -118,7 +118,7 @@
           "@unsorted-dict-items"
           "buildifier: leave-alone"
           (seq (or "buildifier" "buildozer") ": "
-               (seq "disable=" (+ (any "A-Za-z-"))))))
+               "disable=" (+ (any "A-Za-z-")))))
   "Regular expression identifying magic comments known to Buildifier.
 
 Many of these are documented at
@@ -1293,6 +1293,8 @@ strings.  Return either @WORKSPACE//PACKAGE:TARGET or
 If a magic comment was found, return non-nil and set the match to
 the comment text."
   (cl-check-type bound natnum)
+  ;; Buildifier's magic comment detection appears to be case-insensitive, but
+  ;; isn't documented as such.  Reference in the source: https://git.io/JO6FG.
   (let ((case-fold-search t))
     (and (re-search-forward bazel--magic-comment-regexp
                             bound t)

--- a/bazel.el
+++ b/bazel.el
@@ -98,7 +98,7 @@
                (seq "disable=" (+ (any "A-Za-z-"))))))
   "Regular expression identifying magic comments known to Buildifier.
 
-Many of these are documentedat
+Many of these are documented at
 URL `https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md'.
 
 The magic comments \"keep sorted\", \"do not sort\", and

--- a/test.el
+++ b/test.el
@@ -275,11 +275,34 @@ that buffer once BODY finishes."
   (with-temp-buffer
     (insert-file-contents
      (expand-file-name "testdata/fill.BUILD" bazel-test--directory))
-    (bazel-mode)
-    (search-forward "# The Foobar files")
-    (let ((before (buffer-string)))
-      (fill-paragraph)
-      (should (equal (buffer-string) before)))))
+    (let ((original-buffer (current-buffer)))
+      (dolist (comment-text
+               '("keep sorted"
+                 "KEEP SORTEd"
+                 "do not sort"
+                 "@unused"
+                 "@unsorted-dict-items"
+                 "buildifier: leave-alone"
+                 "buildifier: disable=foo"
+                 "buildifier: disable=confusing-name"
+                 "BUILDIFIER: DISABLE=CONFUSING-NAME"
+                 "buildozer: disable=git-repository"
+                 ))
+        (ert-info
+            ((format "Magic comment '%s' not kept on its own line" comment-text))
+          (with-temp-buffer
+            (insert-buffer-substring original-buffer)
+            (goto-char (point-min))
+            (bazel-mode)
+
+            (while (search-forward "%MAGIC_COMMENT%" nil t)
+              (replace-match comment-text :fixedcase :literal))
+
+            (goto-char (point-min))
+            (search-forward "# The Foobar files")
+            (let ((before (buffer-string)))
+              (fill-paragraph)
+              (should (equal (buffer-string) before)))))))))
 
 (ert-deftest bazel-build-mode/beginning-of-defun ()
   "Check that ‘beginning-of-defun’ in BUILD buffers moves to the

--- a/test.el
+++ b/test.el
@@ -280,8 +280,9 @@ that buffer once BODY finishes."
     (bazel-mode)
     (let ((before (buffer-string)))
       (while (search-forward "# Test paragraph" nil t)
-        (fill-paragraph))
-      (should (equal (buffer-string) before)))))
+        (ert-info ((format "fill-paragraph on line %d" (line-number-at-pos)))
+          (fill-paragraph)
+          (should (equal (buffer-string) before)))))))
 
 (ert-deftest bazel-build-mode/beginning-of-defun ()
   "Check that ‘beginning-of-defun’ in BUILD buffers moves to the

--- a/test.el
+++ b/test.el
@@ -271,38 +271,15 @@ that buffer once BODY finishes."
                 (expand-file-name "root/bazel-root/external/ws/bbb.h" dir)))))))
 
 (ert-deftest bazel-mode/fill ()
-  "Check that “keep sorted” comments are left alone."
+  "Check that magic comments are left alone."
   (with-temp-buffer
     (insert-file-contents
      (expand-file-name "testdata/fill.BUILD" bazel-test--directory))
-    (let ((original-buffer (current-buffer)))
-      (dolist (comment-text
-               '("keep sorted"
-                 "KEEP SORTEd"
-                 "do not sort"
-                 "@unused"
-                 "@unsorted-dict-items"
-                 "buildifier: leave-alone"
-                 "buildifier: disable=foo"
-                 "buildifier: disable=confusing-name"
-                 "BUILDIFIER: DISABLE=CONFUSING-NAME"
-                 "buildozer: disable=git-repository"
-                 ))
-        (ert-info
-            ((format "Magic comment '%s' not kept on its own line" comment-text))
-          (with-temp-buffer
-            (insert-buffer-substring original-buffer)
-            (goto-char (point-min))
-            (bazel-mode)
-
-            (while (search-forward "%MAGIC_COMMENT%" nil t)
-              (replace-match comment-text :fixedcase :literal))
-
-            (goto-char (point-min))
-            (search-forward "# The Foobar files")
-            (let ((before (buffer-string)))
-              (fill-paragraph)
-              (should (equal (buffer-string) before)))))))))
+    (bazel-mode)
+    (let ((before (buffer-string)))
+      (while (search-forward "# Test paragraph" nil t)
+        (fill-paragraph))
+      (should (equal (buffer-string) before)))))
 
 (ert-deftest bazel-build-mode/beginning-of-defun ()
   "Check that ‘beginning-of-defun’ in BUILD buffers moves to the

--- a/testdata/fill.BUILD
+++ b/testdata/fill.BUILD
@@ -15,7 +15,7 @@
 my_rule(
     name = "lib",
     # The Foobar files.
-    # keep sorted
+    # %MAGIC_COMMENT%
     foobar_files = [
         "bar",
         "foo",

--- a/testdata/fill.BUILD
+++ b/testdata/fill.BUILD
@@ -14,8 +14,28 @@
 
 my_rule(
     name = "lib",
+    # Test paragraph
+    # Keep sorted
+
+    # Test paragraph
+    # do Not sort
+
+    # Test paragraph
+    # @Unused
+
+    # Test paragraph
+    # @unsorted-dict-items
+
+    # Test paragraph
+    # buildifier: leave-alone
+
+    # Test paragraph
+    # buildifier: disable=git-repository
+
+    # Test paragraph
+    # buildozer: disable=confusing-name
+
     # The Foobar files.
-    # %MAGIC_COMMENT%
     foobar_files = [
         "bar",
         "foo",


### PR DESCRIPTION
`buildifier` supports many different magic comments.  The only one supported by
`bazel-mode` right now is "keep sorted", but there are more known to
`buildifier`, including:

- `do not sort`
- `@unused`
- `@unsorted-dict-items`
- `buildifier: leave-alone`
- `buildifier: disable=$SOME_WARNING`
- `buildozer: disable=$SOME_WARNING`

This change replaces the existing static magic comment detection with a regexp
that encompasses the above plus the existing "keep sorted".  The regexp is
stored as a private variable.

Tests are also provided.

My elisp isn't super strong, so any pointers would be greatly appreciated. :)