### PR TITLE
Mark buildifier command as risky.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -92,6 +92,7 @@
 (defcustom bazel-buildifier-command "buildifier"
   "Filename of buildifier executable."
   :type 'file
+  :risky t
   :group 'bazel
   :link '(url-link
           "https://github.com/bazelbuild/buildtools/tree/master/buildifier"))


### PR DESCRIPTION
All variables ending in ‘-command’ are risky by default, but we might as well
be explicit and consistent with ‘bazel-command’.