### PR TITLE
Shorten GitHub action job name.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -17,7 +17,7 @@ on: [push, pull_request]
 
 jobs:
   emacs-stable:
-    name: Run Bazel tests under the latest stable GNU Emacs release
+    name: Latest stable GNU Emacs release
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
The job name is otherwise cut off in the UI.  “Run Bazel tests” is already part
of the action name, so it doesn’t need to be repeated.