### PR TITLE
Rename “target” to “target pattern” in a few instances.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1045,38 +1045,39 @@ the containing workspace.  This function is suitable for
 
 (defun bazel-build (target)
   "Build a Bazel TARGET."
-  (interactive (list (bazel--read-target "build")))
+  (interactive (list (bazel--read-target-pattern "build")))
   (cl-check-type target string)
   (bazel--run-bazel-command "build" target))
 
 (defun bazel-run (target)
   "Build and run a Bazel TARGET."
-  (interactive (list (bazel--read-target "run")))
+  (interactive (list (bazel--read-target-pattern "run")))
   (cl-check-type target string)
   (bazel--run-bazel-command "run" target))
 
 (defun bazel-test (target)
   "Build and run a Bazel test TARGET."
-  (interactive (list (bazel--read-target "test")))
+  (interactive (list (bazel--read-target-pattern "test")))
   (cl-check-type target string)
   (bazel--run-bazel-command "test" target))
 
 (defun bazel-coverage (target)
   "Run Bazel test TARGET with coverage instrumentation enabled."
-  (interactive (list (bazel--read-target "coverage")))
+  (interactive (list (bazel--read-target-pattern "coverage")))
   (cl-check-type target string)
   (bazel--run-bazel-command "coverage" target))
 
-(defun bazel--run-bazel-command (command target)
-  "Run Bazel tool with given COMMAND, e.g. build or run, on the given TARGET."
+(defun bazel--run-bazel-command (command target-pattern)
+  "Run Bazel tool with given COMMAND on the given TARGET-PATTERN.
+COMMAND is a Bazel command such as \"build\" or \"run\"."
   (cl-check-type command string)
-  (cl-check-type target string)
+  (cl-check-type target-pattern string)
   (compile
    (mapconcat #'shell-quote-argument
-              `(,@bazel-command ,command "--" ,target) " ")))
+              `(,@bazel-command ,command "--" ,target-pattern) " ")))
 
-(defun bazel--read-target (command)
-  "Read a Bazel build target from the minibuffer.
+(defun bazel--read-target-pattern (command)
+  "Read a Bazel build target pattern from the minibuffer.
 COMMAND is a Bazel command to be included in the minibuffer prompt."
   (cl-check-type command string)
   (let* ((file-name (or buffer-file-name

--- a/test.el
+++ b/test.el
@@ -433,8 +433,8 @@ the rule."
           (should (eql (next-single-char-property-change (point-min) 'face)
                        (point-max))))))))
 
-(ert-deftest bazel--read-target/root-package ()
-  "Test target completion in the root package."
+(ert-deftest bazel--read-target-pattern/root-package ()
+  "Test target pattern completion in the root package."
   (bazel-test--with-temp-directory dir
     (bazel-test--tangle dir "read-target-root.org")
     (bazel-test--with-file-buffer (expand-file-name "test.cc" dir)
@@ -443,11 +443,11 @@ the rule."
               (lambda (_prompt collection &rest _args)
                 (push collection candidates)
                 (car collection))))
-        (should (equal (bazel--read-target "build") "//:test"))
+        (should (equal (bazel--read-target-pattern "build") "//:test"))
         (should (equal candidates '(("//:test" "//:all" "//..."))))))))
 
-(ert-deftest bazel--read-target/subpackage ()
-  "Test rule completion in a subpackage."
+(ert-deftest bazel--read-target-pattern/subpackage ()
+  "Test target pattern completion in a subpackage."
   (bazel-test--with-temp-directory dir
     (bazel-test--tangle dir "read-target-package.org")
     (bazel-test--with-file-buffer (expand-file-name "package/test.cc" dir)
@@ -456,7 +456,7 @@ the rule."
               (lambda (_prompt collection &rest _args)
                 (push collection candidates)
                 (car collection))))
-        (should (equal (bazel--read-target "build") "//package:test"))
+        (should (equal (bazel--read-target-pattern "build") "//package:test"))
         (should (equal candidates '(("//package:test" "//package:all"
                                      "//package/..."))))))))
 


### PR DESCRIPTION
Targets and target patterns are not the same, and we should be a bit more
precise here.