### PR TITLE
Improve handling of the case of buffers that don’t visit files.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1190,8 +1190,9 @@ COMMAND is a Bazel command such as \"build\" or \"run\"."
   "Read a Bazel build target pattern from the minibuffer.
 COMMAND is a Bazel command to be included in the minibuffer prompt."
   (cl-check-type command string)
-  (let* ((file-name (or buffer-file-name
-                        (user-error "Buffer doesn’t visit a file")))
+  (let* ((file-name
+          (or buffer-file-name default-directory
+              (user-error "Buffer doesn’t visit a file or directory")))
          (workspace-root
           (or (bazel--workspace-root file-name)
               (user-error


### PR DESCRIPTION
We’d also like to allow buffers that don’t visit a file but a directory so that
‘bazel-build’ and friends also work in e.g. Dired buffers.  Also improve the
error reporting if we don’t find a starting point at all.