### PR TITLE
Separate Bazel command and target with a double hyphen.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1059,7 +1059,7 @@ the containing workspace.  This function is suitable for
   (cl-check-type target string)
   (compile
    (mapconcat #'shell-quote-argument
-              (append bazel-command (list command target)) " ")))
+              `(,@bazel-command ,command "--" ,target) " ")))
 
 (defun bazel--read-target (command)
   "Read a Bazel build target from the minibuffer.

--- a/test.el
+++ b/test.el
@@ -548,6 +548,14 @@ in ‘bazel-mode’."
                   (should (equal (add-log-current-defun) expected-name))
                   (should (equal (which-function) expected-name)))))))))))
 
+(ert-deftest bazel-build ()
+  (cl-letf* ((commands ())
+             ((symbol-function #'compile)
+              (lambda (command &optional _comint)
+                (push command commands))))
+    (bazel-build "//foo:bar")
+    (should (equal commands '("bazel build -- //foo\\:bar")))))
+
 (put #'looking-at-p 'ert-explainer #'bazel-test--explain-looking-at-p)
 
 (defun bazel-test--explain-looking-at-p (regexp)


### PR DESCRIPTION
This ensures that Bazel interprets the TARGET argument always as a target, even
if it starts with a hyphen.