### PR TITLE
Fix documentation for ‘bazel--with-file-buffer’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -745,11 +745,11 @@ return nil."
           (match-beginning 2))))))
 
 (defmacro bazel--with-file-buffer (existing filename &rest body)
-  "Evaluate BODY in some buffer that visits FILENAME.
+  "Evaluate BODY in some buffer that contains the contents of FILENAME.
 If there’s an existing buffer visiting FILENAME, use that and
-bind EXISTING to t.  Otherwise, create a new temporary buffer and
-bind EXISTING to nil.  In any case, return the value of the last
-BODY form."
+bind EXISTING to t.  Otherwise, create a new temporary buffer,
+insert the contents of FILENAME there, and bind EXISTING to nil.
+In any case, return the value of the last BODY form."
   (declare (debug (symbolp form body)) (indent 2))
   (cl-check-type existing symbol)
   (macroexp-let2 nil filename filename


### PR DESCRIPTION
The current docstring claims to visit the file, but the macro doesn’t actually
do that.