### PR TITLE
Make `compilation-mode` aware of Starlark's print(), .bzl files

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -874,7 +874,7 @@ Look for an imported file with the given NAME."
                           ;; could be part of the workspace directory name.
                           (group (+ (any alnum ?/ ?- ?. ?_))
                                  (or (seq "/BUILD" (? ".bazel"))
-                                     (seq (+ (any alnum ?- ?. ?_ )) ".bzl")))
+                                     (seq (+ (any alnum ?- ?. ?_)) ".bzl")))
                           ?: (group (+ digit)) ?: (group (+ digit)) ": ")
                     :no-group)
           collect (list name rx 1 2 3 type)))))

--- a/bazel.el
+++ b/bazel.el
@@ -858,7 +858,8 @@ Look for an imported file with the given NAME."
 (let ((entries
        (eval-when-compile
          (cl-loop
-          for (name prefix type) in '((bazel-mode-info "INFO" 0)
+          for (name prefix type) in '((bazel-mode-debug "DEBUG" 0)
+                                      (bazel-mode-info "INFO" 0)
                                       (bazel-mode-warning "WARNING" 1)
                                       (bazel-mode-error "ERROR" 2))
           for rx = (rx-to-string
@@ -872,7 +873,8 @@ Look for an imported file with the given NAME."
                           ;; non-ASCII alphanumeric characters, because they
                           ;; could be part of the workspace directory name.
                           (group (+ (any alnum ?/ ?- ?. ?_))
-                                 "/BUILD" (? ".bazel"))
+                                 (or (seq "/BUILD" (? ".bazel"))
+                                     (seq (+ (any alnum ?- ?. ?_ )) ".bzl")))
                           ?: (group (+ digit)) ?: (group (+ digit)) ": ")
                     :no-group)
           collect (list name rx 1 2 3 type)))))


### PR DESCRIPTION
This change modifies the additions to `compilation-error-regexp-alist` (and
`compilation-error-regexp-alist-alist`) to:

- Be aware of the output from `print()` in Starlark rules, and treat it as
  informational.  Other regexps seem to be picking it up in my setup and
  treating them as errors.

- Expand the regexps to be aware of errors emitted from .bzl files.  These are
  considered the origins of `print`ed lines in Bazel's output.

---

Some other notes:

- I have not provided tests with this, as I'm not sure of the best way to implement them.  I was thinking that `testdata/compile.org` could be modified to have the output of `cc_library` in a macro that has a `print()` and test against `compilation-num-infos-found`.  Any other ideas would be appreciated.

- `print()` outputs may only come from `.bzl` files, everything else seems to come from BUILD files, but I think checking for both is likely harmless.