### PR TITLE
Make Buildifier test more robust.

### DIFF
--- a/testdata/fake_buildifier
+++ b/testdata/fake_buildifier
@@ -14,5 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Fake waiting for file input.
+cat > /dev/null
+
 # Fake some Buildifier output.
 cat -- "${TEST_SRCDIR:?}/${TEST_WORKSPACE:?}/testdata/buildifier.json"


### PR DESCRIPTION
The actual Buildifier needs to read its standard input and can’t exit before
it’s read all of it.  Emulate this behavior in our fake Buildifier.  This issue
caused some test flakiness.