### PR TITLE
Fix filename argument with --compile_one_dependency.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1150,11 +1150,9 @@ the containing workspace.  This function is suitable for
   (interactive)
   (let* ((file-name (or buffer-file-name
                         (user-error "Buffer doesn’t visit a file")))
-         ;; “bazel build --compile_one_dependency” wants file names relative to
-         ;; the workspace root.
-         (workspace-root (or (bazel--workspace-root file-name)
-                             (user-error "File is not in a Bazel workspace")))
-         (relative-name (file-relative-name file-name workspace-root)))
+         ;; “bazel build --compile_one_dependency” accepts file names relative
+         ;; to the current directory.
+         (relative-name (file-relative-name file-name)))
     (bazel--compile "build" "--compile_one_dependency" "--" relative-name)))
 
 (defun bazel-run (target)

--- a/test.el
+++ b/test.el
@@ -658,15 +658,17 @@ in ‘bazel-mode’."
     (write-region "" nil (expand-file-name "package/BUILD" dir))
     (write-region "" nil (expand-file-name "package/test.cc" dir))
     (bazel-test--with-file-buffer (expand-file-name "package/test.cc" dir)
-      (cl-letf* ((commands nil)
-                 ((symbol-function #'compile)
-                  (lambda (command &optional _comint)
-                    (push command commands))))
-        (bazel-compile-current-file)
-        (should
-         (equal
-          commands
-          '("bazel build --compile_one_dependency -- package/test.cc")))))))
+      (dolist (case `((,dir (,(concat "bazel build --compile_one_dependency "
+                                      "-- package/test.cc")))
+                      (,(expand-file-name "package" dir)
+                       ("bazel build --compile_one_dependency -- test.cc"))))
+        (cl-destructuring-bind (default-directory want-commands) case
+          (cl-letf* ((got-commands ())
+                     ((symbol-function #'compile)
+                      (lambda (command &optional _comint)
+                        (push command got-commands))))
+            (bazel-compile-current-file)
+            (should (equal got-commands want-commands))))))))
 
 (put #'looking-at-p 'ert-explainer #'bazel-test--explain-looking-at-p)
 


### PR DESCRIPTION
Experimentally these must be filenames relative to the current directory, not
the workspace root.