### PR TITLE
Update prompt for target pattern completion.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1204,7 +1204,7 @@ COMMAND is a Bazel command to be included in the minibuffer prompt."
               (user-error "Not in a Bazel package.  No BUILD file found")))
          (initial-input (concat "//" package-name))
          (prompt (combine-and-quote-strings
-                  (append bazel-command (list command ""))))
+                  `(,@bazel-command "--" ,command "")))
          (table
           (bazel--target-pattern-completion-table workspace-root package-name)))
     (completing-read prompt table nil nil initial-input)))


### PR DESCRIPTION
Commit cb47bff663d618b5730cd366701e1c57036b4179 introduced a double hyphen to
separate the targets, so the prompt should do the same, to avoid the impression
that the user can specify flag arguments here.