### PR TITLE
Fix Edebug specification of ‘bazel-test--with-file-buffer’ macro.

### DIFF
--- a/test.el
+++ b/test.el
@@ -162,7 +162,7 @@ BODY finishes."
   "Visit FILENAME in a temporary buffer.
 Execute BODY with the buffer that visits FILENAME current.  Kill
 that buffer once BODY finishes."
-  (declare (indent 1) (debug (sexp body)))
+  (declare (indent 1) (debug t))
   (let ((buffer (make-symbol "buffer")))
     `(let ((,buffer (find-file-noselect ,filename)))
        (unwind-protect


### PR DESCRIPTION
We evaluate all arguments, so the specification for the first argument
shouldn’t be ‘sexp’.