### PR TITLE
Fix naming convention for helper function.

### DIFF
--- a/test.el
+++ b/test.el
@@ -402,10 +402,10 @@ the rule."
       (should (bazel-workspace-root project))
       (should (directory-name-p (bazel-workspace-root project)))
       (should (file-directory-p (bazel-workspace-root project)))
-      (should (bazel-tests--file-equal-p (bazel-workspace-root project) dir))
+      (should (bazel-test--file-equal-p (bazel-workspace-root project) dir))
       (should (consp (project-roots project)))
       (should-not (cdr (project-roots project)))
-      (should (bazel-tests--file-equal-p (car (project-roots project)) dir))
+      (should (bazel-test--file-equal-p (car (project-roots project)) dir))
       (should-not (project-external-roots project)))))
 
 (ert-deftest bazel-test/coverage ()
@@ -730,7 +730,7 @@ using ‘eq’ instead of ‘equal’."
 
 ;; In Emacs 26, ‘file-equal-p’ is buggy and doesn’t work correctly on quoted
 ;; filenames.  We can drop this hack once we stop supporting Emacs 26.
-(defalias 'bazel-tests--file-equal-p
+(defalias 'bazel-test--file-equal-p
   (if (>= emacs-major-version 27) #'file-equal-p
     (lambda (a b)
       (file-equal-p (file-name-unquote a) (file-name-unquote b)))))


### PR DESCRIPTION
We use the ‘bazel-test--’ prefix for all other test helpers.