### PR TITLE
Fix working directory when invoking Buildifier.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -146,6 +146,7 @@ If nil, don’t pass a -type flag to Buildifier.")
   "Format current buffer using buildifier."
   (interactive "*")
   (let ((input-buffer (current-buffer))
+        (directory default-directory)
         (input-file buffer-file-name)
         (buildifier-buffer (get-buffer-create "*buildifier*"))
         ;; Run buildifier on a file to support remote BUILD files.
@@ -157,11 +158,12 @@ If nil, don’t pass a -type flag to Buildifier.")
       (with-current-buffer buildifier-buffer
         (setq-local inhibit-read-only t)
         (erase-buffer)
-        (let ((return-code
-               (apply #'process-file
-                      bazel-buildifier-command buildifier-input-file
-                      `(t ,buildifier-error-file) nil
-                      (bazel--buildifier-file-flags type input-file))))
+        (let* ((default-directory directory)
+               (return-code
+                (apply #'process-file
+                       bazel-buildifier-command buildifier-input-file
+                       `(t ,buildifier-error-file) nil
+                       (bazel--buildifier-file-flags type input-file))))
           (if (eq return-code 0)
               (progn
                 (set-buffer input-buffer)


### PR DESCRIPTION
The working directory of the *Buildifier* buffer is arbitrary and might even
not exist any more by the time we start Buildifier.  It might also be on the
wrong remote host.  Instead, take over working directory from the original
buffer.