### PR TITLE
Enable ‘bug-reference-prog-mode’ in Emacs Lisp files.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((mode . bug-reference-prog)
+                     (bug-reference-url-format . "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=%s"))))

--- a/bazel.el
+++ b/bazel.el
@@ -1485,7 +1485,7 @@ If FILE-NAME is not in a Bazel package, return nil."
   (cl-check-type file-name string)
   (cl-check-type workspace-root string)
   (when (< emacs-major-version 27)
-    ;; Work around https://debbugs.gnu.org/cgi/bugreport.cgi?bug=29579.
+    ;; Work around Bug#29579.
     (cl-callf file-name-unquote file-name)
     (cl-callf file-name-unquote workspace-root))
   (let* ((parent (file-name-directory (directory-file-name workspace-root)))

--- a/test.el
+++ b/test.el
@@ -67,8 +67,7 @@
   "Unit test for ‘bazel--make-diagnostics’.
 We test that function instead of the Flymake backend directly so
 we don’t have to start or mock a process."
-  ;; This test doesn’t work in Emacs 27 due to
-  ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=39971.
+  ;; This test doesn’t work in Emacs 27 due to Bug#39971.
   (skip-unless (not (eql emacs-major-version 27)))
   (with-temp-buffer
     (let ((output-buffer (current-buffer))
@@ -231,8 +230,7 @@ that buffer once BODY finishes."
                                    (marker-buffer
                                     (xref-location-marker
                                      (xref-item-location def))))))
-                    ;; Work around
-                    ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=46219.
+                    ;; Work around Bug#46219.
                     (cl-callf file-name-unquote root)
                     (cl-callf file-name-unquote ref-file)
                     (push (list (substring-no-properties identifier)


### PR DESCRIPTION
This allows us to refer to Emacs bugs using a shorthand notation.