### PR TITLE
Skip convenience symlinks when completing root packages.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1767,7 +1767,14 @@ and include wildcards.  This is a helper function for
                         (completion-table-merge
                          (bazel--target-package-completion-table-1
                           parent-directory)
-                         (and pattern '("...")))))))
+                         (and pattern '("..."))))))
+             (predicate
+              (if (string-empty-p package)
+                  ;; Skip convenience symlinks in the workspace root.
+                  (lambda (candidate)
+                    (and (not (string-prefix-p "bazel-" candidate))
+                         (if predicate (funcall predicate candidate) t)))
+                predicate)))
         (complete-with-action action table string predicate)))))
 
 (defun bazel--target-package-completion-table-1 (directory)

--- a/test.el
+++ b/test.el
@@ -454,6 +454,7 @@ the rule."
   "Test target completion in the root package."
   (bazel-test--with-temp-directory dir
     (bazel-test--tangle dir "target-completion-root.org")
+    (make-symbolic-link dir (expand-file-name "bazel-out" dir))
     ;; The test cases are of the form (STRING PATTERN TRY ALL TEST BOUND).
     ;; STRING is the input string.  PATTERN specifies whether to complete target
     ;; patterns; if PATTERNS is ‘*’, try both with and without pattern


### PR DESCRIPTION
These can never be packages, and clutter up the completion display.