### PR TITLE
Remove duplicate hyphen from character set.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1825,7 +1825,7 @@ and skip files.  This is a helper function for
                                  (bazel--external-workspace workspace root)))))
     (let ((completion-regexp-list
            (cons (rx bos (+ (any "a-z" "A-Z" "0-9" ?-
-                                 "!%@^_` \"#$&'()*-+,;<=>?[]{|}~/.")
+                                 "!%@^_` \"#$&'()*+,;<=>?[]{|}~/.")
                             eos))
                  completion-regexp-list)))
       (completion-table-merge


### PR DESCRIPTION
In this position, this will denote a character range and therefore be slightly
wrong, see the remark about ‘any’ in
https://www.gnu.org/software/emacs/manual/html_node/elisp/Rx-Constructs.html.