### PR TITLE
Make ‘bazel-test-at-point’ test more robust.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,9 +31,6 @@ elisp_test(
         # due to https://github.com/bazelbuild/bazel/issues/10560.
         "test.el",
     ],
-    data = [
-        "BUILD",
-        "test.el",
-    ] + glob(["testdata/*"]),
+    data = ["BUILD"] + glob(["testdata/*"]),
     deps = [":bazel"],
 )

--- a/test.el
+++ b/test.el
@@ -740,20 +740,20 @@ in ‘bazel-mode’."
               (_ (ert-fail (format "Unexpected arguments %S" got-args))))))))))
 
 (ert-deftest bazel-test-at-point ()
-  (cl-letf* ((case-fold-search nil)
-             (test-file (expand-file-name "test.el" bazel-test--directory))
-             (commands ())
-             ((symbol-function #'compile)
-              (lambda (command &optional _comint)
-                (push command commands))))
-    (bazel-test--with-file-buffer test-file
-      (emacs-lisp-mode)
-      (should-error (bazel-test-at-point) :type 'user-error)
-      (re-search-forward (rx bol "(ert-deftest bazel/project ()"))
-      (bazel-test-at-point))
-    (should
-     (equal commands
-            '("bazel test --test_filter\\=bazel/project -- //\\:bazel_test")))))
+  (bazel-test--with-temp-directory dir
+    (bazel-test--tangle dir "test-at-point.org")
+    (cl-letf* ((case-fold-search nil)
+               (commands ())
+               ((symbol-function #'compile)
+                (lambda (command &optional _comint)
+                  (push command commands))))
+      (bazel-test--with-file-buffer (expand-file-name "foo-test.el" dir)
+        (should-error (bazel-test-at-point) :type 'user-error)
+        (re-search-forward (rx bol "(ert-deftest foo/test ()"))
+        (bazel-test-at-point))
+      (should
+       (equal commands
+              '("bazel test --test_filter\\=foo/test -- //\\:foo_test"))))))
 
 (ert-deftest bazel-test-at-point-functions ()
   "Test that ‘which-function’ is at the end of

--- a/testdata/test-at-point.org
+++ b/testdata/test-at-point.org
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+#+begin_src bazel-workspace :tangle WORKSPACE
+  workspace(name = "root")
+#+end_src
+
+#+begin_src bazel-build :tangle BUILD
+  elisp_test(
+      name = "foo_test",
+      srcs = ["foo-test.el"],
+  )
+#+end_src
+
+#+begin_src emacs-lisp :tangle foo-test.el
+  ;; Comment that is not a test.
+  (ert-deftest foo/test ()
+    (should (foo)))
+#+end_src


### PR DESCRIPTION
Don’t depend on the workspace layout of the emacs-bazel-mode project itself,
but create a hermetic workspace instead, as for the other tests.