### PR TITLE
Don’t reuse BUILD and test.el as test data files.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,6 +30,6 @@ elisp_test(
         # due to https://github.com/bazelbuild/bazel/issues/10560.
         "test.el",
     ],
-    data = ["BUILD"] + glob(["testdata/*"]),
+    data = glob(["testdata/*"]),
     deps = [":bazel"],
 )

--- a/test.el
+++ b/test.el
@@ -117,12 +117,11 @@ that buffer once BODY finishes."
     (should (= (current-column) 4))))
 
 (ert-deftest bazel-mode/indent-region ()
-  (with-temp-buffer
-    (bazel-mode)
-    (insert-file-contents (expand-file-name "BUILD" bazel-test--directory))
-    (let ((before (buffer-string)))
-      (indent-region (point-min) (point-max))
-      (should (equal (buffer-string) before)))))
+  (bazel-test--with-temp-directory dir "indent.org"
+    (bazel-test--with-file-buffer (expand-file-name "BUILD" dir)
+      (let ((before (buffer-string)))
+        (indent-region (point-min) (point-max))
+        (should (equal (buffer-string) before))))))
 
 (ert-deftest bazel--make-diagnostics ()
   "Unit test for ‘bazel--make-diagnostics’.
@@ -306,23 +305,21 @@ we don’t have to start or mock a process."
 (ert-deftest bazel-build-mode/beginning-of-defun ()
   "Check that ‘beginning-of-defun’ in BUILD buffers moves to the
 beginning of the rule."
-  (with-temp-buffer
-    (insert-file-contents (expand-file-name "BUILD" bazel-test--directory))
-    (bazel-build-mode)
-    (search-forward "bazel.el")
-    (beginning-of-defun)
-    (should (looking-at-p (rx bol "elisp_library(" ?\n
-                              "    name = \"bazel\",")))))
+  (bazel-test--with-temp-directory dir "defun-navigation.org"
+    (bazel-test--with-file-buffer (expand-file-name "BUILD" dir)
+      (search-forward "bazel.el")
+      (beginning-of-defun)
+      (should (looking-at-p (rx bol "elisp_library(" ?\n
+                                "    name = \"bazel\","))))))
 
 (ert-deftest bazel-build-mode/end-of-defun ()
   "Check that ‘end-of-defun’ in BUILD buffers moves to the end of
 the rule."
-  (with-temp-buffer
-    (insert-file-contents (expand-file-name "BUILD" bazel-test--directory))
-    (bazel-build-mode)
-    (search-forward "bazel.el")
-    (end-of-defun)
-    (should (looking-back (rx "\n)\n") nil))))
+  (bazel-test--with-temp-directory dir "defun-navigation.org"
+    (bazel-test--with-file-buffer (expand-file-name "BUILD" dir)
+      (search-forward "bazel.el")
+      (end-of-defun)
+      (should (looking-back (rx "\n)\n") nil)))))
 
 (ert-deftest bazel-mode/compile ()
   "Check that \\[next-error] jumps to the correct places."
@@ -378,11 +375,12 @@ the rule."
 
 (ert-deftest bazel-mode/speedbar ()
   "Check that \\[speedbar] detects BUILD files."
-  (with-temp-buffer
-    (speedbar-default-directory-list bazel-test--directory 0)
-    (goto-char (point-min))
-    (let ((case-fold-search nil))
-      (search-forward "BUILD"))))
+  (bazel-test--with-temp-directory dir "speedbar.org"
+    (with-temp-buffer
+      (speedbar-default-directory-list dir 0)
+      (goto-char (point-min))
+      (let ((case-fold-search nil))
+        (search-forward "BUILD")))))
 
 (ert-deftest bazel-mode/triple-quoted-strings ()
   "Check that triple-quoted strings work as expected."

--- a/testdata/defun-navigation.org
+++ b/testdata/defun-navigation.org
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+* Test data for ~bazel-build-mode/beginning-of-defun~ and ~bazel-build-mode/end-of-defun~
+
+#+begin_src bazel-workspace :tangle WORKSPACE
+  workspace(name = "root")
+#+end_src
+
+#+begin_src bazel-build :tangle BUILD
+  # Some comment.
+
+  elisp_library(
+      name = "bazel",
+      srcs = ["bazel.el"],
+  )
+#+end_src

--- a/testdata/indent.org
+++ b/testdata/indent.org
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+* Test data for ~bazel-mode/indent-region~
+
+#+begin_src bazel-workspace :tangle WORKSPACE
+  workspace(name = "root")
+#+end_src
+
+#+begin_src bazel-build :tangle BUILD
+  cc_library(
+      name = "lib",
+      srcs = [
+          "aaa.cc",
+      ] + glob(["*_test.cc"]),
+  )
+#+end_src

--- a/testdata/speedbar.org
+++ b/testdata/speedbar.org
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+* Test data for ~bazel-mode/speedbar~
+
+#+begin_src bazel-workspace :tangle WORKSPACE
+  workspace(name = "root")
+#+end_src
+
+#+begin_src bazel-build :tangle BUILD
+  # Some comment.
+#+end_src


### PR DESCRIPTION
While reusing them saves a bit of space, it’s not very robust.  Use proper test
data for all tests instead.