### PR TITLE
Don’t try to fontify dynamic target names.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1997,7 +1997,9 @@ the match text.  The second match group matches the name."
               (group (any ?\" ?'))
               (group (+ (any "a-z" "A-Z" "0-9" ?-
                              "!%@^_` #$&()*+,;<=>?[]{|}~/.")))
-              (backref 1))
+              ;; Don’t look for dynamic target names such as "foo" + SUFFIX;
+              ;; only fontifying the "foo" part would be confusing.
+              (backref 1) (* blank) (any ?, ?\)))
           bound t)
          (let ((syntax (syntax-ppss)))
            (and (> (nth 0 syntax) 0) (null (nth 8 syntax)))))))

--- a/test.el
+++ b/test.el
@@ -671,7 +671,9 @@ in ‘bazel-mode’."
                '(face font-lock-string-face) "\"*.cc\"" nil "]),\n"
                nil "    alwayslink = "
                '(face font-lock-constant-face) "True" nil ",\n"
-               nil")\n\n")))
+               nil")\n\n"
+               nil "some_rule(name = "
+               '(face font-lock-string-face) "\"foo\"" nil " + SUFFIX)\n\n")))
     (with-temp-buffer
       (bazel-build-mode)
       (insert (substring-no-properties text))


### PR DESCRIPTION
Currently, a constructed target name such as "foo" + SUFFIX would result in
only ‘foo’ fontified, which looks worse than no special fontification.