### PR TITLE
Fix heading formatting.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -154,7 +154,8 @@ If ‘local’, only do so for local files."
   "Face for lines not covered by unit tests."
   :group 'bazel)
 
-;;;; Commands to run Buildifier.
+;;;; Commands to run Buildifier
+
 (defvar-local bazel--buildifier-type nil
   "Type of the file that the current buffer visits.
 This must be a symbol and a valid value for the Buildifier -type


### PR DESCRIPTION
It’s a heading, so it shouldn’t end in a period.  It should also be preceded
and followed by an empty line, like the other headings.