### PR TITLE
Remove unnecessary load path entry.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,6 @@ load("@phst_rules_elisp//elisp:defs.bzl", "elisp_library", "elisp_test")
 elisp_library(
     name = "bazel",
     srcs = ["bazel.el"],
-    load_path = ["."],
     visibility = ["//obsolete:__pkg__"],
 )
 


### PR DESCRIPTION
Since the library file is in the workspace root, it’s already in the load path
by default.