### PR TITLE
Add a test case for running the Python test at point.

### DIFF
--- a/test.el
+++ b/test.el
@@ -755,6 +755,25 @@ in ‘bazel-mode’."
      (equal commands
             '("bazel test --test_filter\\=bazel/project -- //\\:bazel_test")))))
 
+(ert-deftest bazel-test-at-point/python-mode ()
+  "Test ‘bazel-test-at-point’ in ‘python-mode’."
+  (bazel-test--with-temp-directory dir
+    (bazel-test--tangle dir "test-at-point-python.org")
+    (cl-letf* ((commands ())
+               ((symbol-function #'compile)
+                (lambda (command &optional _comint)
+                  (push command commands))))
+      (bazel-test--with-file-buffer (expand-file-name "py_test.py" dir)
+        (should-error (bazel-test-at-point) :type 'user-error)
+        (search-forward "# Test case class")
+        (bazel-test-at-point)
+        (search-forward "# Test method")
+        (bazel-test-at-point))
+      (should
+       (equal (reverse commands)
+              '("bazel test --test_filter\\=MyTest -- //\\:py_test"
+                "bazel test --test_filter\\=MyTest.testFoo -- //\\:py_test"))))))
+
 (ert-deftest bazel-test-at-point-functions ()
   "Test that ‘which-function’ is at the end of
 ‘bazel-test-at-point-functions’."

--- a/testdata/test-at-point-python.org
+++ b/testdata/test-at-point-python.org
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+#+begin_src bazel-workspace :tangle WORKSPACE
+  workspace(name = "root")
+#+end_src
+
+#+begin_src bazel-build :tangle BUILD
+  py_test(
+      name = "py_test",
+      srcs = ["py_test.py"],
+  )
+#+end_src
+
+#+begin_src python :tangle py_test.py
+  # Comment
+
+  from absl.testing import absltest
+
+  class MyTest(absltest.TestCase):
+
+      # Test case class
+
+      def testFoo(self):
+          # Test method
+          self.assertEqual(1, 2)
+
+
+  if __name__ == '__main__':
+      absltest.main()
+#+end_src


### PR DESCRIPTION
The default ‘which-function’ works fine for this, so no code changes are
needed.