### PR TITLE
Replace a bug URL by a short reference.

### DIFF
--- a/test.el
+++ b/test.el
@@ -122,8 +122,7 @@ that buffer once BODY finishes."
   "Unit test for ‘bazel--make-diagnostics’.
 We test that function instead of the Flymake backend directly so
 we don’t have to start or mock a process."
-  ;; This test doesn’t work in Emacs 27 due to
-  ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=39971.
+  ;; This test doesn’t work in Emacs 27 due to Bug#39971.
   (skip-unless (not (eql emacs-major-version 27)))
   (bazel-test--with-temp-directory dir
     (bazel-test--tangle dir "flymake.org")


### PR DESCRIPTION
This was accidentally reverted in commit
4fd5143307fd0d3cae570cbdcffadfe206cd9d45.