### PR TITLE
Move ‘skip-unless’ form to an earlier time.

### DIFF
--- a/test.el
+++ b/test.el
@@ -423,24 +423,24 @@ the rule."
 
 (ert-deftest bazel/project-files ()
   "Test ‘project-files’ support for Bazel workspaces."
-  (bazel-test--with-temp-directory dir "project.org"
-    (let* ((dir (file-name-unquote dir))  ; unquote to work around Bug#47799
-           ;; Try to work around Bug#48471 by picking GNU find on macOS.
-           (find-program (if (eq system-type 'darwin) "gfind" find-program))
-           (project (project-current nil dir))
-           (files (cond ((fboundp 'project-files)  ; Emacs 27
-                         (project-files project))
-                        ((fboundp 'project-file-completion-table)  ; Emacs 26
-                         (all-completions "" (project-file-completion-table
-                                              project (list dir)))))))
-      (skip-unless (executable-find find-program))
-      (should project)
-      (should (bazel-workspace-p project))
-      (should files)
-      (should (equal (sort (cl-loop for file in files
-                                    collect (file-relative-name file dir))
-                           #'string-lessp)
-                     '(".bazelignore" "WORKSPACE" "package/BUILD"))))))
+  ;; Try to work around Bug#48471 by picking GNU find on macOS.
+  (let ((find-program (if (eq system-type 'darwin) "gfind" find-program)))
+    (skip-unless (executable-find find-program))
+    (bazel-test--with-temp-directory dir "project.org"
+      (let* ((dir (file-name-unquote dir))  ; unquote to work around Bug#47799
+             (project (project-current nil dir))
+             (files (cond ((fboundp 'project-files)  ; Emacs 27
+                           (project-files project))
+                          ((fboundp 'project-file-completion-table)  ; Emacs 26
+                           (all-completions "" (project-file-completion-table
+                                                project (list dir)))))))
+        (should project)
+        (should (bazel-workspace-p project))
+        (should files)
+        (should (equal (sort (cl-loop for file in files
+                                      collect (file-relative-name file dir))
+                             #'string-lessp)
+                       '(".bazelignore" "WORKSPACE" "package/BUILD")))))))
 
 (ert-deftest bazel-test/coverage ()
   "Test coverage parsing and display."


### PR DESCRIPTION
We need the ‘find-program’ for ‘project-files’, so skipping the test after
calling ‘project-files’ won’t work.