### PR TITLE
Add dedicated history variable for target pattern completion.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1574,6 +1574,10 @@ COMMAND is a Bazel command such as \"build\" or \"run\"."
   "Run Bazel in a Compilation buffer with the given ARGS."
   (compile (mapconcat #'shell-quote-argument (append bazel-command args) " ")))
 
+(defvar bazel-target-history nil
+  "History for Bazel target pattern completion.
+See Info node ‘(elisp) Minibuffer History’.")
+
 (defun bazel--read-target-pattern (command)
   "Read a Bazel build target pattern from the minibuffer.
 COMMAND is a Bazel command to be included in the minibuffer prompt."
@@ -1593,7 +1597,7 @@ COMMAND is a Bazel command to be included in the minibuffer prompt."
                                                 :pattern))
          (default (bazel--target-completion-default
                    buffer-file-name workspace-root package-name)))
-    (completing-read prompt table nil nil nil nil default)))
+    (completing-read prompt table nil nil nil 'bazel-target-history default)))
 
 (defun bazel--target-completion-default (source-file root package)
   "Return default completion target for SOURCE-FILE.

--- a/test.el
+++ b/test.el
@@ -1083,7 +1083,8 @@ in ‘bazel-mode’."
                     (push command compile-commands))))
         (call-interactively #'bazel-test)
         (pcase completing-read-args
-          (`(("bazel -- test " ,_ nil nil nil nil "//:test" nil)))
+          (`(("bazel -- test " ,_ nil nil nil bazel-target-history
+              "//:test" nil)))
           (_ (ert-fail (list "Invalid arguments to ‘completing-read’"
                              completing-read-args))))
         (should (equal compile-commands '("bazel test -- \\:test")))))))


### PR DESCRIPTION
This is specific enough that it deserves its own history.