### PR TITLE
Shorten URLs pointing to the “master” version of the Bazel docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ infrastructure like [compilation][] and [xref][].  See the commentary in
 
 [Bazel]: https://bazel.build/
 [GNU Emacs]: https://www.gnu.org/software/emacs/
-[BUILD files]: https://docs.bazel.build/versions/master/build-ref.html#BUILD_files
-[WORKSPACE files]: https://docs.bazel.build/versions/master/build-ref.html#packages_targets
-[.bazelrc files]: https://docs.bazel.build/versions/master/guide.html#bazelrc
-[Starlark files]: https://docs.bazel.build/versions/master/skylark/language.html
-[run Bazel commands]: https://docs.bazel.build/versions/master/guide.html
+[BUILD files]: https://docs.bazel.build/build-ref.html#BUILD_files
+[WORKSPACE files]: https://docs.bazel.build/build-ref.html#packages_targets
+[.bazelrc files]: https://docs.bazel.build/guide.html#bazelrc
+[Starlark files]: https://docs.bazel.build/skylark/language.html
+[run Bazel commands]: https://docs.bazel.build/guide.html
 [compilation]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation.html
 [xref]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html

--- a/bazel.el
+++ b/bazel.el
@@ -408,8 +408,7 @@ This is the parent mode for the more specific modes
 
 (define-skeleton bazel-insert-http-archive
   "Insert an “http_archive” statement at point.
-See URL
-‘https://docs.bazel.build/versions/master/repo/http.html#http_archive’
+See URL ‘https://docs.bazel.build/repo/http.html#http_archive’
 for a description of “http_archive”.  Interactively, prompt for
 an archive URL.  Attempt to detect workspace name and prefix.
 Also add the date when the archive was likely last modified as a


### PR DESCRIPTION
These shorter URLs redirect to the right location.