### PR TITLE
Use short options in the make_*_out scripts.

### DIFF
--- a/testdata/make_compile_out
+++ b/testdata/make_compile_out
@@ -25,8 +25,8 @@ workspace="$(bazel info workspace)" || exit
 testdata="${workspace:?}/testdata"
 org="${testdata:?}/compile.org"
 
-dir="$(mktemp --directory)" || exit
-trap 'rm --recursive --force -- "${dir}"' EXIT
+dir="$(mktemp -d)" || exit
+trap 'rm -r -f -- "${dir}"' EXIT
 
 # Set up a basic workspace layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
@@ -48,11 +48,10 @@ out="${out//${execroot}/%ROOTDIR%}"
 
 # We can’t use ‘org-babel-detangle’ because there are no links in the tangled
 # files.
-awk --lint=fatal \
-  --assign out=bazel.out --assign src=<(echo "${out:?}") \
-  --file "${testdata:?}/detangle.awk" \
+awk -v out=bazel.out -v src=<(echo "${out:?}") \
+  -f "${testdata:?}/detangle.awk" \
   -- "${org:?}" > "${dir:?}/org.tmp" || exit
 
-cp --no-target-directory -- "${dir:?}/org.tmp" "${org:?}" || exit
+cp -- "${dir:?}/org.tmp" "${org:?}" || exit
 
 echo 'Successfully refreshed compile.org'

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -26,8 +26,8 @@ workspace="$(bazel info workspace)" || exit
 testdata="${workspace:?}/testdata"
 org="${testdata:?}/coverage.org"
 
-dir="$(mktemp --directory)" || exit
-trap 'rm --recursive --force -- "${dir}"' EXIT
+dir="$(mktemp -d)" || exit
+trap 'rm -r -f -- "${dir}"' EXIT
 
 # Set up a basic workspace layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
@@ -51,15 +51,13 @@ out="${out//${execroot}/%ROOTDIR%}"
 
 # We can’t use ‘org-babel-detangle’ because there are no links in the tangled
 # files.
-awk --lint=fatal \
-  --assign out=bazel.out --assign src=<(echo "${out:?}") \
-  --file "${testdata:?}/detangle.awk" \
+awk -v out=bazel.out -v src=<(echo "${out:?}") \
+  -f "${testdata:?}/detangle.awk" \
   -- "${org:?}" > "${dir:?}/org.tmp" || exit
 
-awk --lint=fatal \
-  --assign out=bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat \
-  --assign src="${dat:?}" \
-  --file "${testdata:?}/detangle.awk" \
+awk -v out=bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat \
+  -v src="${dat:?}" \
+  -f "${testdata:?}/detangle.awk" \
   -- "${dir:?}/org.tmp" > "${org:?}" || exit
 
 echo 'Successfully refreshed coverage.org.'


### PR DESCRIPTION
This makes them work on macOS (and presumably BSD systems), which don’t ship
the GNU coreutils.