### PR TITLE
Canonicalize temporary directory names.

### DIFF
--- a/testdata/make_compile_out
+++ b/testdata/make_compile_out
@@ -28,6 +28,10 @@ org="${testdata:?}/compile.org"
 dir="$(mktemp --directory)" || exit
 trap 'rm --recursive --force -- "${dir}"' EXIT
 
+# Canonicalize the directory so that the textual replacement below doesn’t
+# choke on symbolic links.
+dir="$(realpath -e -- "${dir:?}")" || exit
+
 # Set up a basic workspace layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
   --eval="(let ((default-directory \"${dir:?}/\")) (org-babel-tangle))" || exit

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -29,6 +29,10 @@ org="${testdata:?}/coverage.org"
 dir="$(mktemp --directory)" || exit
 trap 'rm --recursive --force -- "${dir}"' EXIT
 
+# Canonicalize the directory so that the textual replacement below doesn’t
+# choke on symbolic links.
+dir="$(realpath -e -- "${dir:?}")" || exit
+
 # Set up a basic workspace layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
   --eval="(let ((default-directory \"${dir:?}/\")) (org-babel-tangle))" || exit


### PR DESCRIPTION
This is necessary if the output of “mktemp” is a symbolic link (e.g. on macOS).