### PR TITLE
Switch coverage test from C++ to Java.

### DIFF
--- a/test.el
+++ b/test.el
@@ -413,23 +413,22 @@ the rule."
   "Test coverage parsing and display."
   ;; Set up a fake workspace and execution root.  We use DIR for both.
   (bazel-test--with-temp-directory dir "coverage.org"
-    (let* ((package-dir (expand-file-name "package" dir))
-           (library (expand-file-name "library.h" package-dir)))
+    (let* ((package-dir (expand-file-name "src/main/java/example" dir))
+           (library (expand-file-name "Example.java" package-dir)))
       (bazel-test--with-file-buffer library
         (let ((case-fold-search nil))
           (with-temp-buffer
             (let ((default-directory dir)
                   (bazel-display-coverage 'local))
               (insert-file-contents (expand-file-name "bazel.out" dir))
-              ;; The coverage overlays don’t logically change the buffer
-              ;; contents.  Ensure that the code works even if the buffer is
-              ;; read-only.
+              ;; The coverage overlays don’t logically change the buffer contents.
+              ;; Ensure that the code works even if the buffer is read-only.
               (setq buffer-read-only t)
               ;; Simulate successful exit of the Bazel process.
               (compilation-handle-exit 'exit 0 "finished\n")))
           (ert-info ("Comment line")
-            ;; Comment line isn’t covered at all.
-            (should (looking-at-p (rx bol "//")))
+            ;; Package declaration isn’t covered at all.
+            (should (looking-at-p (rx bol "package ")))
             (should-not (face-at-point)))
           (ert-info ("Covered line")
             (search-forward "return 137;")

--- a/testdata/coverage.org
+++ b/testdata/coverage.org
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Set up a fake workspace and execution root in the current directory.
+* Test data for coverage tests
+
+Set up a fake workspace and execution root in the current directory.  We use a
+Java library because C++ and Python coverage is quite broken.  Specifically,
+[[https://github.com/bazelbuild/bazel/issues/10457][C++ coverage doesn’t work
+on macOS]], and [[https://github.com/bazelbuild/bazel/issues/10660][Python
+coverage doesn’t work at all]].  Java coverage still
+[[https://github.com/bazelbuild/bazel/issues/13358][suffers from some bugs]],
+but can at least be made to work somewhat reliably.
 
 #+property: header-args :mkdirp yes :main no
 
@@ -20,51 +28,72 @@ Set up a fake workspace and execution root in the current directory.
   workspace(name = "test")
 #+end_src
 
-#+begin_src bazel-build :tangle package/BUILD
-  cc_library(
-      name = "library",
-      hdrs = ["library.h"],
-  )
+We follow the
+[[https://docs.bazel.build/versions/4.1.0/bazel-and-java.html#best-practices][Java-specific
+best practices]].
 
-  cc_test(
-      name = "library_test",
-      srcs = ["library_test.cc"],
-      deps = [":library"],
+#+begin_src bazel-build :tangle src/main/java/example/BUILD
+  java_library(
+      name = "example",
+      srcs = glob(["*.java"]),
+      visibility = ["//src/test/java/example:__pkg__"],
   )
 #+end_src
 
-#+begin_src C++ :tangle package/library.h
-  // Comment
-  inline int Function(bool arg) {
-    if (arg) {
-      return 137;
-    } else {
-      return 42;
-    }
+#+begin_src bazel-build :tangle src/test/java/example/BUILD
+  java_test(
+      name = "example_test",
+      srcs = glob(["*.java"]),
+      test_class = "example.ExampleTest",
+      deps = ["//src/main/java/example"],
+  )
+#+end_src
+
+#+begin_src java :tangle src/main/java/example/Example.java
+  package example;
+
+  public class Example {
+      public static int function(boolean arg) {
+          if (arg) {
+              return 137;
+          } else {
+              return 42;
+          }
+      }
   }
 #+end_src
 
-#+begin_src C++ :tangle package/library_test.cc
-  #include <cstdlib>
+#+begin_src java :tangle src/test/java/example/ExampleTest.java
+  package example;
 
-  #include "library.h"
+  import static org.junit.Assert.assertEquals;
+  import org.junit.Test;
 
-  int main() {
-    return Function(true) == 137 ? EXIT_SUCCESS : EXIT_FAILURE;
+  public class ExampleTest {
+      @Test
+      public void function() {
+          assertEquals(137, Example.function(true));
+      }
   }
 #+end_src
 
-#+begin_src fundamental :tangle bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat
-  SF:package/library.h
-  FN:2,_Z8Functionb
-  FNDA:1,_Z8Functionb
-  FNF:1
+#+begin_src fundamental :tangle bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
+  SF:src/main/java/example/Example.java
+  FN:3,example/Example::<init> ()V
+  FN:5,example/Example::function (Z)I
+  FNDA:0,example/Example::<init> ()V
+  FNDA:1,example/Example::function (Z)I
+  FNF:2
   FNH:1
-  DA:2,1
-  DA:3,1
-  DA:4,1
-  DA:6,0
-  LH:3
+  BRDA:5,0,0,1
+  BRDA:5,0,1,0
+  BRF:2
+  BRH:1
+  DA:3,0
+  DA:5,1
+  DA:6,1
+  DA:8,0
+  LH:2
   LF:4
   end_of_record
 #+end_src
@@ -74,31 +103,31 @@ Merged standard output and error from Bazel:
 #+begin_src fundamental :tangle bazel.out
   Loading: 
   Loading: 0 packages loaded
-  INFO: Using default value for --instrumentation_filter: "^//package[/:]".
+  INFO: Using default value for --instrumentation_filter: "^//src/main/java/example[/:]".
   INFO: Override the above default with --instrumentation_filter
-  Analyzing: 2 targets (1 packages loaded, 0 targets configured)
-  Analyzing: 2 targets (12 packages loaded, 18 targets configured)
-  Analyzing: 2 targets (23 packages loaded, 309 targets configured)
-  Analyzing: 2 targets (24 packages loaded, 358 targets configured)
-  Analyzing: 2 targets (24 packages loaded, 358 targets configured)
-  INFO: Analyzed 2 targets (25 packages loaded, 508 targets configured).
+  Analyzing: 2 targets (2 packages loaded, 0 targets configured)
+  Analyzing: 2 targets (13 packages loaded, 49 targets configured)
+  Analyzing: 2 targets (13 packages loaded, 49 targets configured)
+  Analyzing: 2 targets (24 packages loaded, 377 targets configured)
+  Analyzing: 2 targets (25 packages loaded, 423 targets configured)
+  Analyzing: 2 targets (26 packages loaded, 587 targets configured)
+  INFO: Analyzed 2 targets (27 packages loaded, 764 targets configured).
   INFO: Found 1 target and 1 test target...
   WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
-    cannot create symbolic link bazel-out -> %ROOTDIR%/bazel-out:  /tmp/tmp.86VdonwqKw/bazel-out (File exists)
+    cannot create symbolic link bazel-out -> %ROOTDIR%/bazel-out:  /private/var/folders/hw/0wwmn4393436_1ylv82fksbr0000gn/T/tmp.IMTNZh4zkw/bazel-out (File exists)
   bazel: Entering directory `%ROOTDIR%/'
-  [0 / 8] [Prepa] BazelWorkspaceStatusAction stable-status.txt ... (4 actions, 0 running)
-  [12 / 16] [Prepa] Action external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class
-  [13 / 16] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 0s linux-sandbox
-  [13 / 16] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 2s linux-sandbox
-  [15 / 16] Testing //package:library_test; 0s linux-sandbox
+  [0 / 11] Testing //src/test/java/example:example_test [[0s] (2 actions)]
+  [8 / 13] Action external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class; 1s darwin-sandbox
+  [10 / 13] Compiling Java headers src/main/java/example/libexample-hjar.jar (1 source file); 0s darwin-sandbox ... (2 actions running)
+  [19 / 22] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 0s darwin-sandbox
   bazel: Leaving directory `%ROOTDIR%/'
-  INFO: Elapsed time: 12.290s, Critical Path: 4.71s
-  INFO: 16 processes: 9 internal, 6 linux-sandbox, 1 worker.
-  INFO: Build completed successfully, 16 total actions
-  //package:library_test                                                   PASSED in 0.6s
-    %ROOTDIR%/bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat
+  INFO: Elapsed time: 13,736s, Critical Path: 4,19s
+  INFO: 22 processes: 12 internal, 7 darwin-sandbox, 3 worker.
+  INFO: Build completed successfully, 22 total actions
+  //src/test/java/example:example_test                                     PASSED in 0.7s
+    %ROOTDIR%/bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
   
   Executed 1 out of 1 test: 1 test passes.
   There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
-  INFO: Build completed successfully, 16 total actions
+  INFO: Build completed successfully, 22 total actions
 #+end_src

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -41,7 +41,7 @@ execroot="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info execution_root)"
 
 # We explicitly compile with the current directory set to a subdirectory to
 # ensure that workspace-relative filenames still work as expected.
-out="$(cd "${dir:?}/package" && bazel --bazelrc=/dev/null coverage //... 2>&1)"
+out="$(cd "${dir:?}/src" && bazel --bazelrc=/dev/null coverage //... 2>&1)"
 
 # Parse output to find location of coverage.dat.  The output should be
 # relatively stable,
@@ -59,7 +59,7 @@ awk -v out=bazel.out -v src=<(echo "${out:?}") \
   -f "${testdata:?}/detangle.awk" \
   -- "${org:?}" > "${dir:?}/org.tmp" || exit
 
-awk -v out=bazel-out/k8-fastbuild/testlogs/package/library_test/coverage.dat \
+awk -v out=bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat \
   -v src="${dat:?}" \
   -f "${testdata:?}/detangle.awk" \
   -- "${dir:?}/org.tmp" > "${org:?}" || exit


### PR DESCRIPTION
Java coverage instrumentation has fewer bugs; in particular, it works on macOS
as well.