### PR TITLE
Explicitly move to the end of the coverage record.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1264,7 +1264,8 @@ information in the current buffer and fills in COVERAGE."
                   (data (or (gethash buffer coverage)
                             (puthash buffer (make-hash-table :test #'eql)
                                      coverage))))
-              (cl-incf (gethash line data 0) hits))))))))
+              (cl-incf (gethash line data 0) hits)))
+          (goto-char end))))))
 
 (defun bazel--display-coverage (buffer coverage)
   "Add overlays for coverage information in BUFFER.


### PR DESCRIPTION
This shouldn’t change semantics, but makes it more obvious that we start the
next record.