### PR TITLE
Also define an implementation for ‘project-root’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1419,6 +1419,10 @@ the containing workspace.  This function is suitable for
   (when-let ((root (bazel--workspace-root directory)))
     (make-bazel-workspace :root root)))
 
+(cl-defmethod project-root ((project bazel-workspace))
+  "Return the primary root directory of the Bazel workspace PROJECT."
+  (bazel-workspace-root project))
+
 (cl-defmethod project-roots ((project bazel-workspace))
   "Return the primary root directory of the Bazel workspace PROJECT."
   (list (bazel-workspace-root project)))

--- a/test.el
+++ b/test.el
@@ -416,6 +416,7 @@ the rule."
       (should (directory-name-p (bazel-workspace-root project)))
       (should (file-directory-p (bazel-workspace-root project)))
       (should (bazel-test--file-equal-p (bazel-workspace-root project) dir))
+      (should (bazel-test--file-equal-p (project-root project) dir))
       (should (consp (project-roots project)))
       (should-not (cdr (project-roots project)))
       (should (bazel-test--file-equal-p (car (project-roots project)) dir))


### PR DESCRIPTION
‘project-root’ is new in Project 0.3, but defining it unconditionally does no
harm – older Project versions will just ignore it.