### PR TITLE
Suppress obsolescence warnings for ‘project-roots’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1433,9 +1433,20 @@ the containing workspace.  This function is suitable for
   "Return the primary root directory of the Bazel workspace PROJECT."
   (bazel-workspace-root project))
 
-(cl-defmethod project-roots ((project bazel-workspace))
-  "Return the primary root directory of the Bazel workspace PROJECT."
-  (list (bazel-workspace-root project)))
+(eval-when-compile
+  (defmacro bazel--with-suppressed-warnings (warnings &rest body)
+    "Suppress WARNINGS in BODY.
+This is the same as ‘with-suppressed-warnings’ if available.
+Otherwise, just evaluate BODY."
+    (declare (indent 1) (debug (sexp body)))
+    (if (macrop 'with-suppressed-warnings)
+        `(with-suppressed-warnings ,warnings ,@body)
+      (macroexp-progn body))))
+
+(bazel--with-suppressed-warnings ((obsolete project-roots))
+  (cl-defmethod project-roots ((project bazel-workspace))
+    "Return the primary root directory of the Bazel workspace PROJECT."
+    (list (bazel-workspace-root project))))
 
 (cl-defmethod project-external-roots ((project bazel-workspace))
   "Return the external workspace roots of the Bazel workspace PROJECT."


### PR DESCRIPTION
This generic function is obsolete in Project 0.3 and later, but we still want
to support it in all versions.  Therefore, suppress the byte-compile warning
when defining and testing the method.  This requires a new macro because
‘with-suppressed-warnings’ isn’t available in Emacs 26.