### PR TITLE
Don’t indent paragraphs and source code blocks in Org mode.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,4 +3,6 @@
 
 ((emacs-lisp-mode . ((mode . bug-reference-prog)
                      (bug-reference-url-format . "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=%s")))
+ (org-mode . ((org-adapt-indentation . nil)
+              (org-edit-src-content-indentation . 0)))
  (nil . ((fill-column . 80))))

--- a/testdata/bazelrc.org
+++ b/testdata/bazelrc.org
@@ -15,13 +15,13 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazelrc :tangle .bazelrc
-  import %workspace%/other.bazelrc
+import %workspace%/other.bazelrc
 #+end_src
 
 #+begin_src bazelrc :tangle other.bazelrc
-  build --verbose_failures
+build --verbose_failures
 #+end_src

--- a/testdata/compile.org
+++ b/testdata/compile.org
@@ -15,46 +15,46 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+begin_src bazel-build :tangle package/BUILD
-  cc_library(
-      name = "test",
-      srcs = ["test.cc"],
-      deprecation = "Deprecated!",
-  )
+cc_library(
+    name = "test",
+    srcs = ["test.cc"],
+    deprecation = "Deprecated!",
+)
 #+end_src
 
 #+begin_src C++ :tangle package/test.cc
-  UnknownType foo;
+UnknownType foo;
 #+end_src
 
 Merged standard output and error from Bazel:
 
 #+begin_src fundamental :tangle bazel.out
-  Loading: 
-  Loading: 0 packages loaded
-  WARNING: %ROOTDIR%/package/BUILD:1:11: target '//package:test' is deprecated: Deprecated!
-  Analyzing: target //package:test (1 packages loaded, 0 targets configured)
-  Analyzing: target //package:test (11 packages loaded, 18 targets configured)
-  INFO: Analyzed target //package:test (15 packages loaded, 51 targets configured).
-  INFO: Found 1 target...
-  bazel: Entering directory `%ROOTDIR%/'
-  [0 / 6] [Prepa] Writing file package/libtest.a-2.params ... (3 actions, 0 running)
-  ERROR: %ROOTDIR%/package/BUILD:1:11: Compiling package/test.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 16 argument(s) skipped)
-  
-  Use --sandbox_debug to see verbose messages from the sandbox gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 16 argument(s) skipped)
-  
-  Use --sandbox_debug to see verbose messages from the sandbox
-  package/test.cc:1:1: error: 'UnknownType' does not name a type
-      1 | UnknownType foo;
-        | ^~~~~~~~~~~
-  bazel: Leaving directory `%ROOTDIR%/'
-  Target //package:test failed to build
-  Use --verbose_failures to see the command lines of failed build steps.
-  INFO: Elapsed time: 1.702s, Critical Path: 0.04s
-  INFO: 4 processes: 4 internal.
-  FAILED: Build did NOT complete successfully
-  FAILED: Build did NOT complete successfully
+Loading: 
+Loading: 0 packages loaded
+WARNING: %ROOTDIR%/package/BUILD:1:11: target '//package:test' is deprecated: Deprecated!
+Analyzing: target //package:test (1 packages loaded, 0 targets configured)
+Analyzing: target //package:test (11 packages loaded, 18 targets configured)
+INFO: Analyzed target //package:test (15 packages loaded, 51 targets configured).
+INFO: Found 1 target...
+bazel: Entering directory `%ROOTDIR%/'
+[0 / 6] [Prepa] Writing file package/libtest.a-2.params ... (3 actions, 0 running)
+ERROR: %ROOTDIR%/package/BUILD:1:11: Compiling package/test.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 16 argument(s) skipped)
+
+Use --sandbox_debug to see verbose messages from the sandbox gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 16 argument(s) skipped)
+
+Use --sandbox_debug to see verbose messages from the sandbox
+package/test.cc:1:1: error: 'UnknownType' does not name a type
+    1 | UnknownType foo;
+      | ^~~~~~~~~~~
+bazel: Leaving directory `%ROOTDIR%/'
+Target //package:test failed to build
+Use --verbose_failures to see the command lines of failed build steps.
+INFO: Elapsed time: 1.702s, Critical Path: 0.04s
+INFO: 4 processes: 4 internal.
+FAILED: Build did NOT complete successfully
+FAILED: Build did NOT complete successfully
 #+end_src

--- a/testdata/completion-at-point.org
+++ b/testdata/completion-at-point.org
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  cc_library(
-      name = "lib",
-      srcs = ["lib.cc"],
-  )
+cc_library(
+    name = "lib",
+    srcs = ["lib.cc"],
+)
 
-  cc_binary(
-      name = "bin",
-      srcs = ["bin.cc"],
-      deps = ["//:li"],
-  )
+cc_binary(
+    name = "bin",
+    srcs = ["bin.cc"],
+    deps = ["//:li"],
+)
 #+end_src

--- a/testdata/coverage.org
+++ b/testdata/coverage.org
@@ -25,7 +25,7 @@ but can at least be made to work somewhat reliably.
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 We follow the
@@ -33,101 +33,101 @@ We follow the
 best practices]].
 
 #+begin_src bazel-build :tangle src/main/java/example/BUILD
-  java_library(
-      name = "example",
-      srcs = glob(["*.java"]),
-      visibility = ["//src/test/java/example:__pkg__"],
-  )
+java_library(
+    name = "example",
+    srcs = glob(["*.java"]),
+    visibility = ["//src/test/java/example:__pkg__"],
+)
 #+end_src
 
 #+begin_src bazel-build :tangle src/test/java/example/BUILD
-  java_test(
-      name = "example_test",
-      srcs = glob(["*.java"]),
-      test_class = "example.ExampleTest",
-      deps = ["//src/main/java/example"],
-  )
+java_test(
+    name = "example_test",
+    srcs = glob(["*.java"]),
+    test_class = "example.ExampleTest",
+    deps = ["//src/main/java/example"],
+)
 #+end_src
 
 #+begin_src java :tangle src/main/java/example/Example.java
-  package example;
+package example;
 
-  public class Example {
-      public static int function(boolean arg) {
-          if (arg) {
-              return 137;
-          } else {
-              return 42;
-          }
-      }
-  }
+public class Example {
+    public static int function(boolean arg) {
+        if (arg) {
+            return 137;
+        } else {
+            return 42;
+        }
+    }
+}
 #+end_src
 
 #+begin_src java :tangle src/test/java/example/ExampleTest.java
-  package example;
+package example;
 
-  import static org.junit.Assert.assertEquals;
-  import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
-  public class ExampleTest {
-      @Test
-      public void function() {
-          assertEquals(137, Example.function(true));
-      }
-  }
+public class ExampleTest {
+    @Test
+    public void function() {
+        assertEquals(137, Example.function(true));
+    }
+}
 #+end_src
 
 #+begin_src fundamental :tangle bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
-  SF:src/main/java/example/Example.java
-  FN:3,example/Example::<init> ()V
-  FN:5,example/Example::function (Z)I
-  FNDA:0,example/Example::<init> ()V
-  FNDA:1,example/Example::function (Z)I
-  FNF:2
-  FNH:1
-  BRDA:5,0,0,1
-  BRDA:5,0,1,0
-  BRF:2
-  BRH:1
-  DA:3,0
-  DA:5,1
-  DA:6,1
-  DA:8,0
-  LH:2
-  LF:4
-  end_of_record
+SF:src/main/java/example/Example.java
+FN:3,example/Example::<init> ()V
+FN:5,example/Example::function (Z)I
+FNDA:0,example/Example::<init> ()V
+FNDA:1,example/Example::function (Z)I
+FNF:2
+FNH:1
+BRDA:5,0,0,1
+BRDA:5,0,1,0
+BRF:2
+BRH:1
+DA:3,0
+DA:5,1
+DA:6,1
+DA:8,0
+LH:2
+LF:4
+end_of_record
 #+end_src
 
 Merged standard output and error from Bazel:
 
 #+begin_src fundamental :tangle bazel.out
-  Loading: 
-  Loading: 0 packages loaded
-  INFO: Using default value for --instrumentation_filter: "^//src/main/java/example[/:]".
-  INFO: Override the above default with --instrumentation_filter
-  Analyzing: 2 targets (2 packages loaded, 0 targets configured)
-  Analyzing: 2 targets (13 packages loaded, 49 targets configured)
-  Analyzing: 2 targets (13 packages loaded, 49 targets configured)
-  Analyzing: 2 targets (24 packages loaded, 377 targets configured)
-  Analyzing: 2 targets (25 packages loaded, 423 targets configured)
-  Analyzing: 2 targets (26 packages loaded, 587 targets configured)
-  INFO: Analyzed 2 targets (27 packages loaded, 764 targets configured).
-  INFO: Found 1 target and 1 test target...
-  WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
-    cannot create symbolic link bazel-out -> %ROOTDIR%/bazel-out:  /private/var/folders/hw/0wwmn4393436_1ylv82fksbr0000gn/T/tmp.IMTNZh4zkw/bazel-out (File exists)
-  bazel: Entering directory `%ROOTDIR%/'
-  [0 / 11] Testing //src/test/java/example:example_test [[0s] (2 actions)]
-  [8 / 13] Action external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class; 1s darwin-sandbox
-  [10 / 13] Compiling Java headers src/main/java/example/libexample-hjar.jar (1 source file); 0s darwin-sandbox ... (2 actions running)
-  [19 / 22] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 0s darwin-sandbox
-  bazel: Leaving directory `%ROOTDIR%/'
-  INFO: Elapsed time: 13,736s, Critical Path: 4,19s
-  INFO: 22 processes: 12 internal, 7 darwin-sandbox, 3 worker.
-  INFO: Build completed successfully, 22 total actions
-  //src/test/java/example:example_test                                     PASSED in 0.7s
-    %ROOTDIR%/bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
-  
-  Executed 1 out of 1 test: 1 test passes.
-  There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
-  INFO: Build completed successfully, 22 total actions
+Loading: 
+Loading: 0 packages loaded
+INFO: Using default value for --instrumentation_filter: "^//src/main/java/example[/:]".
+INFO: Override the above default with --instrumentation_filter
+Analyzing: 2 targets (2 packages loaded, 0 targets configured)
+Analyzing: 2 targets (13 packages loaded, 49 targets configured)
+Analyzing: 2 targets (13 packages loaded, 49 targets configured)
+Analyzing: 2 targets (24 packages loaded, 377 targets configured)
+Analyzing: 2 targets (25 packages loaded, 423 targets configured)
+Analyzing: 2 targets (26 packages loaded, 587 targets configured)
+INFO: Analyzed 2 targets (27 packages loaded, 764 targets configured).
+INFO: Found 1 target and 1 test target...
+WARNING: failed to create one or more convenience symlinks for prefix 'bazel-':
+  cannot create symbolic link bazel-out -> %ROOTDIR%/bazel-out:  /private/var/folders/hw/0wwmn4393436_1ylv82fksbr0000gn/T/tmp.IMTNZh4zkw/bazel-out (File exists)
+bazel: Entering directory `%ROOTDIR%/'
+[0 / 11] Testing //src/test/java/example:example_test [[0s] (2 actions)]
+[8 / 13] Action external/bazel_tools/tools/jdk/platformclasspath_classes/DumpPlatformClassPath.class; 1s darwin-sandbox
+[10 / 13] Compiling Java headers src/main/java/example/libexample-hjar.jar (1 source file); 0s darwin-sandbox ... (2 actions running)
+[19 / 22] Action external/bazel_tools/tools/jdk/platformclasspath.jar; 0s darwin-sandbox
+bazel: Leaving directory `%ROOTDIR%/'
+INFO: Elapsed time: 13,736s, Critical Path: 4,19s
+INFO: 22 processes: 12 internal, 7 darwin-sandbox, 3 worker.
+INFO: Build completed successfully, 22 total actions
+//src/test/java/example:example_test                                     PASSED in 0.7s
+  %ROOTDIR%/bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
+
+Executed 1 out of 1 test: 1 test passes.
+There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
+INFO: Build completed successfully, 22 total actions
 #+end_src

--- a/testdata/defun-navigation.org
+++ b/testdata/defun-navigation.org
@@ -17,14 +17,14 @@
 * Test data for ~bazel-build-mode/beginning-of-defun~ and ~bazel-build-mode/end-of-defun~
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  # Some comment.
+# Some comment.
 
-  elisp_library(
-      name = "bazel",
-      srcs = ["bazel.el"],
-  )
+elisp_library(
+    name = "bazel",
+    srcs = ["bazel.el"],
+)
 #+end_src

--- a/testdata/detangle.awk
+++ b/testdata/detangle.awk
@@ -21,7 +21,7 @@ BEGIN {
 
 /^#\+begin_src .+ :tangle / && $4 == out {
   print
-  while ((getline < src) == 1) print "  " $0
+  while ((getline < src) == 1) print
   close(src)
   in_block = 1
   next

--- a/testdata/find-file-at-point.org
+++ b/testdata/find-file-at-point.org
@@ -17,24 +17,24 @@
 * Test data for the ~bazel-mode/ffap~ test
 
 #+begin_src bazel-workspace :tangle root/WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src C :tangle root/aaa.h
-  // Dummy file
+// Dummy file
 #+end_src
 
 #+begin_src C :tangle root/pkg/aaa.c
-  #include "aaa.h"
-  #include "bbb.h"
+#include "aaa.h"
+#include "bbb.h"
 #+end_src
 
 Files in an external workspace:
 
 #+begin_src bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
-  workspace(name = "ws")
+workspace(name = "ws")
 #+end_src
 
 #+begin_src C :tangle root/bazel-root/external/ws/bbb.h
-  // Dummy file
+// Dummy file
 #+end_src

--- a/testdata/flymake.org
+++ b/testdata/flymake.org
@@ -17,14 +17,14 @@
 * Test data for ~bazel-mode-flymake~
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+name: starlark
 #+begin_src bazel-starlark :tangle buildifier.bzl
-  def foo(bar):
-      """ """
-      a = 1 / 2
+def foo(bar):
+    """ """
+    a = 1 / 2
 #+end_src
 
 To make the Flymake test hermetic, we generate Buildifier output statically and
@@ -32,9 +32,9 @@ tangle the output when running the test.  Execute this code block to regenerate
 the Buildifier output:
 
 #+begin_src sh :noweb yes :results output scalar :wrap "src js :tangle buildifier.json"
-  buildifier -mode=check -lint=warn -format=json -v -path=buildifier.bzl <<'EOF'
-  <<starlark>>
-  EOF
+buildifier -mode=check -lint=warn -format=json -v -path=buildifier.bzl <<'EOF'
+<<starlark>>
+EOF
 #+end_src
 
 #+RESULTS:
@@ -98,9 +98,9 @@ the Buildifier output:
 We also provide a “fake” Buildifier binary that only emits our canned output.
 
 #+begin_src sh :tangle buildifier :shebang "#!/bin/bash" :var dir=(file-name-unquote (expand-file-name default-directory))
-  # Fake waiting for file input.
-  cat > /dev/null
+# Fake waiting for file input.
+cat > /dev/null
 
-  # Fake some Buildifier output.
-  cat -- "${dir:?}/buildifier.json"
+# Fake some Buildifier output.
+cat -- "${dir:?}/buildifier.json"
 #+end_src

--- a/testdata/http-archive.org
+++ b/testdata/http-archive.org
@@ -16,25 +16,25 @@
 
 ** Contents of the test repository archive
 
-   #+begin_src bazel-workspace :tangle prefix/WORKSPACE :mkdirp yes
-     workspace(name = "test_repository")
-   #+end_src
+#+begin_src bazel-workspace :tangle prefix/WORKSPACE :mkdirp yes
+workspace(name = "test_repository")
+#+end_src
 
-   #+begin_src bazel-build :tangle prefix/BUILD :mkdirp yes
-     # Empty BUILD file
-   #+end_src
+#+begin_src bazel-build :tangle prefix/BUILD :mkdirp yes
+# Empty BUILD file
+#+end_src
 
 ** Expected ~http_workspace~ snippet
 
-   The ~bazel-insert-http-archive~ test fakes a date of 2019-05-02.
+The ~bazel-insert-http-archive~ test fakes a date of 2019-05-02.
 
-   #+begin_src bazel-workspace :tangle WORKSPACE.expected
-     http_archive(
-         name = "test_repository",
-         sha256 = "%sha256%",
-         strip_prefix = "prefix/",
-         urls = [
-             "%url%",  # 2019-05-02
-         ],
-     )
-   #+end_src
+#+begin_src bazel-workspace :tangle WORKSPACE.expected
+http_archive(
+    name = "test_repository",
+    sha256 = "%sha256%",
+    strip_prefix = "prefix/",
+    urls = [
+        "%url%",  # 2019-05-02
+    ],
+)
+#+end_src

--- a/testdata/indent.org
+++ b/testdata/indent.org
@@ -17,26 +17,26 @@
 * Test data for ~bazel-mode/indent-region~
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  cc_library(
-      name = "lib",
-      srcs = [
-          "aaa.cc",
-      ] + glob(["*_test.cc"]),
-  )
+cc_library(
+    name = "lib",
+    srcs = [
+        "aaa.cc",
+    ] + glob(["*_test.cc"]),
+)
 
-  # A slightly more complex construct.
-  [
-      cc_binary(
-          name = name,
-          srcs = name + ".cc",
-      )
-      for name in [
-          "bin-a",
-          "bin-b",
-      ]
-  ]
+# A slightly more complex construct.
+[
+    cc_binary(
+        name = name,
+        srcs = name + ".cc",
+    )
+    for name in [
+        "bin-a",
+        "bin-b",
+    ]
+]
 #+end_src

--- a/testdata/project.org
+++ b/testdata/project.org
@@ -17,41 +17,41 @@
 * Test data for project tests
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+begin_src fundamental :tangle bazel-out
-  Dummy symbolic link
+Dummy symbolic link
 #+end_src
 
 #+begin_src bazelignore :tangle .bazelignore
-  ignored-directory/
-  # comment
-  ignored directory # with number sign
+ignored-directory/
+# comment
+ignored directory # with number sign
 #+end_src
 
 #+begin_src bazel-build :tangle package/BUILD
-  cc_library(
-      name = "lib",
-      srcs = [
-          "aaa.cc",
-          "dir/bbb.cc",
-          ":aaa.cc",
-          "//:aaa.cc",
-          "//pkg:ccc.cc",
-          "@ws//pkg:ddd.cc",
-      ],
-  )
+cc_library(
+    name = "lib",
+    srcs = [
+        "aaa.cc",
+        "dir/bbb.cc",
+        ":aaa.cc",
+        "//:aaa.cc",
+        "//pkg:ccc.cc",
+        "@ws//pkg:ddd.cc",
+    ],
+)
 
-  cc_binary(
-      name = "bin",
-      deps = [
-          ":lib",
-          "//:lib",
-          "//pkg",
-          "//pkg:lib",
-      ],
-  )
+cc_binary(
+    name = "bin",
+    deps = [
+        ":lib",
+        "//:lib",
+        "//pkg",
+        "//pkg:lib",
+    ],
+)
 #+end_src
 
 ** Files in ignored subdirectories
@@ -60,9 +60,9 @@ The contents don’t matter; we add these files so that the directories are
 created.
 
 #+begin_src bazel-build :tangle ignored-directory/BUILD
-  # Empty file
+# Empty file
 #+end_src
 
 #+begin_src bazel-build :tangle "ignored directory # with number sign/BUILD"
-  # Empty file
+# Empty file
 #+end_src

--- a/testdata/speedbar.org
+++ b/testdata/speedbar.org
@@ -17,9 +17,9 @@
 * Test data for ~bazel-mode/speedbar~
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  # Some comment.
+# Some comment.
 #+end_src

--- a/testdata/target-completion-package.org
+++ b/testdata/target-completion-package.org
@@ -15,17 +15,17 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+begin_src bazel-build :tangle package/BUILD
-  cc_library(
-      name = "test",
-      srcs = ["test.cc"],
-      deprecation = "Deprecated!",
-  )
+cc_library(
+    name = "test",
+    srcs = ["test.cc"],
+    deprecation = "Deprecated!",
+)
 #+end_src
 
 #+begin_src C++ :tangle package/test.cc
-  UnknownType foo;
+UnknownType foo;
 #+end_src

--- a/testdata/target-completion-root.org
+++ b/testdata/target-completion-root.org
@@ -13,30 +13,30 @@
 # limitations under the License.
 
 #+begin_src bazel-workspace :tangle WORKSPACE :main no
-  workspace(name = "test")
+workspace(name = "test")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  cc_library(
-      name = "test",
-      srcs = ["test.cc"],
-      deprecation = "Deprecated!",
-  )
+cc_library(
+    name = "test",
+    srcs = ["test.cc"],
+    deprecation = "Deprecated!",
+)
 
-  py_test(
-      name = "foo_test",
-      srcs = ["foo_test.py"],
-  )
+py_test(
+    name = "foo_test",
+    srcs = ["foo_test.py"],
+)
 #+end_src
 
 #+begin_src C++ :tangle test.cc
-  UnknownType foo;
+UnknownType foo;
 #+end_src
 
 #+begin_src python :tangle foo_test.py
-  import unittest
+import unittest
 
-  class FooTest(unittest.TestCase):
-      def testFoo(self):
-          self.assertEquals(1, 2)
+class FooTest(unittest.TestCase):
+    def testFoo(self):
+        self.assertEquals(1, 2)
 #+end_src

--- a/testdata/test-at-point-c++.org
+++ b/testdata/test-at-point-c++.org
@@ -15,22 +15,22 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  cc_test(
-      name = "cc_test",
-      srcs = ["cc_test.cc"],
-  )
+cc_test(
+    name = "cc_test",
+    srcs = ["cc_test.cc"],
+)
 #+end_src
 
 #+begin_src C++ :tangle cc_test.cc
-  // Comment
-  TEST(FooTest, Bar) {
-    EXPECT_EQ(1, 2);
-  }
-  TEST_F(BazTest, Qux) {
-    EXPECT_EQ(4, 5);
-  }
+// Comment
+TEST(FooTest, Bar) {
+  EXPECT_EQ(1, 2);
+}
+TEST_F(BazTest, Qux) {
+  EXPECT_EQ(4, 5);
+}
 #+end_src

--- a/testdata/test-at-point-elisp.org
+++ b/testdata/test-at-point-elisp.org
@@ -15,28 +15,28 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  elisp_library(
-      name = "foo",
-      srcs = ["foo.el"],
-  )
+elisp_library(
+    name = "foo",
+    srcs = ["foo.el"],
+)
 
-  elisp_test(
-      name = "foo_test",
-      srcs = ["foo-test.el"],
-  )
+elisp_test(
+    name = "foo_test",
+    srcs = ["foo-test.el"],
+)
 #+end_src
 
 #+begin_src emacs-lisp :tangle foo.el
-  (ert-deftest foo/not-really-a-test ()
-    (should (foo)))
+(ert-deftest foo/not-really-a-test ()
+  (should (foo)))
 #+end_src
 
 #+begin_src emacs-lisp :tangle foo-test.el
-  ;; Comment that is not a test.
-  (ert-deftest foo/test ()
-    (should (foo)))
+;; Comment that is not a test.
+(ert-deftest foo/test ()
+  (should (foo)))
 #+end_src

--- a/testdata/test-at-point-go.org
+++ b/testdata/test-at-point-go.org
@@ -15,22 +15,22 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  go_test(
-      name = "go_test",
-      srcs = ["go_test.go"],
-  )
+go_test(
+    name = "go_test",
+    srcs = ["go_test.go"],
+)
 #+end_src
 
 #+begin_src go :tangle go_test.go
-  // Comment
-  func Test(t *testing.T) {
-          t.Error("Failed!")
-  }
-  func BenchmarkFoo_Bar(b *testing.B) {
-          b.Error("Failed!")
-  }
+// Comment
+func Test(t *testing.T) {
+        t.Error("Failed!")
+}
+func BenchmarkFoo_Bar(b *testing.B) {
+        b.Error("Failed!")
+}
 #+end_src

--- a/testdata/test-at-point-python.org
+++ b/testdata/test-at-point-python.org
@@ -15,30 +15,30 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle BUILD
-  py_test(
-      name = "py_test",
-      srcs = ["py_test.py"],
-  )
+py_test(
+    name = "py_test",
+    srcs = ["py_test.py"],
+)
 #+end_src
 
 #+begin_src python :tangle py_test.py
-  # Comment
+# Comment
 
-  from absl.testing import absltest
+from absl.testing import absltest
 
-  class MyTest(absltest.TestCase):
+class MyTest(absltest.TestCase):
 
-      # Test case class
+    # Test case class
 
-      def testFoo(self):
-          # Test method
-          self.assertEqual(1, 2)
+    def testFoo(self):
+        # Test method
+        self.assertEqual(1, 2)
 
 
-  if __name__ == '__main__':
-      absltest.main()
+if __name__ == '__main__':
+    absltest.main()
 #+end_src

--- a/testdata/xref.org
+++ b/testdata/xref.org
@@ -15,57 +15,57 @@
 #+property: header-args :mkdirp yes :main no
 
 #+begin_src bazel-workspace :tangle root/WORKSPACE
-  workspace(name = "root")
+workspace(name = "root")
 #+end_src
 
 #+begin_src bazel-build :tangle root/BUILD
-  cc_library(
-      name = "lib",
-      srcs = [
-          "aaa.cc",
-          "dir/bbb.cc",
-          ":aaa.cc",
-          "//:aaa.cc",
-          "//pkg:ccc.cc",
-          "@ws//pkg:ddd.cc",
-      ],
-  )
+cc_library(
+    name = "lib",
+    srcs = [
+        "aaa.cc",
+        "dir/bbb.cc",
+        ":aaa.cc",
+        "//:aaa.cc",
+        "//pkg:ccc.cc",
+        "@ws//pkg:ddd.cc",
+    ],
+)
 
-  cc_binary(
-      name = "bin",
-      deps = [
-          ":lib",
-          "//:lib",
-          "//pkg",
-          "//pkg:lib",
-      ],
-  )
+cc_binary(
+    name = "bin",
+    deps = [
+        ":lib",
+        "//:lib",
+        "//pkg",
+        "//pkg:lib",
+    ],
+)
 #+end_src
 
 Create empty files that the labels in the test BUILD file refer to.
 
 #+begin_src C++ :tangle root/aaa.cc
-  // empty
+// empty
 #+end_src
 
 #+begin_src C++ :tangle root/dir/bbb.cc
-  // empty
+// empty
 #+end_src
 
 #+begin_src bazel-build :tangle root/pkg/BUILD
-  # empty
+# empty
 #+end_src
 
 #+begin_src C++ :tangle root/pkg/ccc.cc
-  // empty
+// empty
 #+end_src
 
 Files in an external workspace:
 
 #+begin_src bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
-  # empty
+# empty
 #+end_src
 
 #+begin_src C++ :tangle root/bazel-root/external/ws/pkg/ddd.cc
-  // empty
+// empty
 #+end_src


### PR DESCRIPTION
This is merely a question of style, but personally I prefer not indenting these
elements because they are easily recognizable without indentation.