### PR TITLE
Make Bazel target public.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,7 @@ load("@phst_rules_elisp//elisp:defs.bzl", "elisp_library", "elisp_test")
 elisp_library(
     name = "bazel",
     srcs = ["bazel.el"],
-    visibility = ["//obsolete:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 elisp_test(


### PR DESCRIPTION
Since this is a public library, there’s no need to restrict its Bazel
visibility.