### PR TITLE
Revert back to using ‘xargs’ for coverage script.

### DIFF
--- a/coverage
+++ b/coverage
@@ -25,14 +25,9 @@ trap 'rm -f -- "${log}"' EXIT
 bazel coverage -- //... | tee -- "${log:?}" || exit
 echo
 
-mapfile -t dat < <(sed -r -n -e 's|^  (/.+/coverage\.dat)$|\1|p' -- "${log:?}")
-
-if ((${#dat[@]} == 0)); then
-  echo 'No coverage output found' >&2
-  exit 1
-fi
-
-genhtml --output-directory=coverage-report --branch-coverage \
-  -- "${dat[@]}" || exit
+sed -r -n -e 's|^  (/.+/coverage\.dat)$|\1|p' -- "${log:?}" \
+  | tr '\n' '\0' \
+  | xargs -0 -r -t -- \
+  genhtml --output-directory=coverage-report --branch-coverage -- || exit
 
 echo "Coverage report written to ${root}/coverage-report" >&2


### PR DESCRIPTION
The ancient default Bash version on macOS doesn’t support ‘mapfile’.
Since the coverage report is never required for correctness, precise error
handling isn’t that important here.