### PR TITLE
Fix font locking of target names for rules that have only a name.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -2386,7 +2386,7 @@ the match text.  The second match group matches the name."
               ;; only fontifying the "foo" part would be confusing.
               (backref 1) (* blank) (any ?, ?\)))
           bound t)
-         (let ((syntax (syntax-ppss)))
+         (let ((syntax (syntax-ppss (match-beginning 0))))
            (and (> (nth 0 syntax) 0) (null (nth 8 syntax)))))))
 
 (defun bazel--find-magic-comment (bound)

--- a/test.el
+++ b/test.el
@@ -741,7 +741,11 @@ in ‘bazel-mode’."
                '(face font-lock-constant-face) "True" nil ",\n"
                nil")\n\n"
                nil "some_rule(name = "
-               '(face font-lock-string-face) "\"foo\"" nil " + SUFFIX)\n\n")))
+               '(face font-lock-string-face) "\"foo\"" nil " + SUFFIX)\n\n"
+               nil "name_only(name = " '(face font-lock-string-face) "\""
+               '(face (font-lock-variable-name-face font-lock-string-face))
+               "foo"
+               '(face font-lock-string-face) "\"" nil ")\n\n")))
     (with-temp-buffer
       (bazel-build-mode)
       (insert (substring-no-properties text))


### PR DESCRIPTION
For rules of the form

    rule_name(name = "target_name")

we shouldn’t look at the syntax of the end of the match, because that’s already
outside the parentheses and therefore doesn’t pass the first condition.