### PR TITLE
Correctly anchor search for “name” attributes.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -2426,7 +2426,7 @@ the match text.  The second match group matches the name."
   (cl-check-type bound natnum)
   (let ((case-fold-search nil))
     (and (re-search-forward
-          (rx "name" (* blank) ?= (* blank)
+          (rx symbol-start "name" (* blank) ?= (* blank)
               (group (any ?\" ?'))
               (group (+ (any "a-z" "A-Z" "0-9" ?-
                              "!%@^_` #$&()*+,;<=>?[]{|}~/.")))

--- a/test.el
+++ b/test.el
@@ -755,7 +755,11 @@ in ‘bazel-mode’."
                nil "name_only(name = " '(face font-lock-string-face) "\""
                '(face (font-lock-variable-name-face font-lock-string-face))
                "foo"
-               '(face font-lock-string-face) "\"" nil ")\n\n")))
+               '(face font-lock-string-face) "\"" nil ")\n\n"
+               nil "some_rule(\n"
+               nil "    filename = "
+               '(face font-lock-string-face) "\"file.txt\"" nil ",\n"
+               nil ")\n\n")))
     (with-temp-buffer
       (bazel-build-mode)
       (insert (substring-no-properties text))


### PR DESCRIPTION
We should only match a “name” attribute that is a full symbol, otherwise this
would match attributes such as “filename”.