### PR TITLE
Fix syntax of various punctuation characters.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -277,6 +277,20 @@ mentioned in the Buildifier source code at URL
     (modify-syntax-entry ?\n ">" table)
     ;; strings using single quotes
     (modify-syntax-entry ?' "\"" table)
+    ;; Some characters are word or symbol constituents in
+    ;; ‘standard-syntax-table’, but should be punctuation characters in
+    ;; ‘bazel-mode’.
+    (modify-syntax-entry ?$ "." table)
+    (modify-syntax-entry ?% "." table)
+    (modify-syntax-entry ?& "." table)
+    (modify-syntax-entry ?* "." table)
+    (modify-syntax-entry ?+ "." table)
+    (modify-syntax-entry ?- "." table)
+    (modify-syntax-entry ?/ "." table)
+    (modify-syntax-entry ?< "." table)
+    (modify-syntax-entry ?= "." table)
+    (modify-syntax-entry ?> "." table)
+    (modify-syntax-entry ?| "." table)
     table)
   "Syntax table for `bazel-mode'.")
 

--- a/test.el
+++ b/test.el
@@ -739,6 +739,8 @@ in ‘bazel-mode’."
                '(face font-lock-string-face) "\"*.cc\"" nil "]),\n"
                nil "    alwayslink = "
                '(face font-lock-constant-face) "True" nil ",\n"
+               nil "    linkstatic="
+               '(face font-lock-constant-face) "True" nil ",\n"
                nil")\n\n"
                nil "some_rule(name = "
                '(face font-lock-string-face) "\"foo\"" nil " + SUFFIX)\n\n")))


### PR DESCRIPTION
By default, these are word or symbol constituents, but that’s wrong in BUILD or
Starlark files.  In particular, treating the equals sign as a symbol constituent
leads to incorrect fontification of things like “linkstatic=True”, because the
“True” wouldn’t be a full symbol.