### PR TITLE
Also unquote Buildifier error file.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -183,7 +183,7 @@ the file types documented at URL
                   (apply #'process-file
                          bazel-buildifier-command
                          (maybe-unquote buildifier-input-file)
-                         `(t ,buildifier-error-file) nil
+                         `(t ,(maybe-unquote buildifier-error-file)) nil
                          (bazel--buildifier-file-flags type input-file))))
             (if (eq return-code 0)
                 (progn


### PR DESCRIPTION
Seems like this is occasionally necessary on Emacs 27 as well.