### PR TITLE
Remove bogus ‘add-hook’ form.

### DIFF
--- a/test.el
+++ b/test.el
@@ -951,8 +951,6 @@ in ‘bazel-mode’."
       (with-temp-buffer
         (insert "input")
         (bazel-starlark-mode)
-        (add-hook 'temp-buffer-window-show-hook
-                   nil :local)
         (let ((tick-before (buffer-modified-tick))
               (temp-buffer-window-show-hook
                (list (lambda () (push (current-buffer) temp-buffers)))))


### PR DESCRIPTION
This isn’t even syntactically valid and only worked by accident.
The ‘temp-buffer-window-show-hook’ is dynamically bound right below.