### PR TITLE
Allow Buildifier file type ‘default’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -173,11 +173,11 @@ temporary file.  After BODY finishes, delete the temporary files."
   "Format current buffer using Buildifier.
 If TYPE is nil, detect the file type from the current major mode
 and visited filename, if available.  Otherwise, TYPE must be one
-of the symbols ‘build’, ‘bzl’, or ‘workspace’, corresponding to
-the file types documented at URL
+of the symbols ‘build’, ‘bzl’, ‘workspace’, or ‘default’,
+corresponding to the file types documented at URL
 ‘https://github.com/bazelbuild/buildtools/tree/master/buildifier#usage’."
   (interactive "*")
-  (cl-check-type type (member nil build bzl workspace))
+  (cl-check-type type (member nil build bzl workspace default))
   (let ((input-buffer (current-buffer))
         (directory default-directory)
         (input-file buffer-file-name)

--- a/test.el
+++ b/test.el
@@ -982,7 +982,8 @@ in ‘bazel-mode’."
       (set-file-modes bazel-buildifier-command #o0500)
       (pcase-dolist (`(,type ,args)
                      '((nil "-type=bzl")
-                       (workspace "-type=workspace")))
+                       (workspace "-type=workspace")
+                       (default "-type=default")))
         (ert-info ((symbol-name type) :prefix "Explicit type: ")
           (with-temp-buffer
             (insert "input")


### PR DESCRIPTION
We don’t use it anywhere, but there’s no reason to ban it.