### PR TITLE
Add a customization option to specify command options.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -51,7 +51,28 @@
   'bazel-command "2021-04-13")
 
 (defcustom bazel-command '("bazel")
-  "Command and arguments that should be used to invoke Bazel."
+  "Command and arguments that should be used to invoke Bazel.
+The arguments are used as startup options; see URL
+‘https://docs.bazel.build/user-manual.html#startup_options’.  To
+add command options, use the option ‘bazel-command-options’
+instead.  Instead of specifying startup options here, it’s
+typically preferable to use a ‘.bazelrc’ file instead; see URL
+‘https://docs.bazel.build/guide.html#bazelrc-the-bazel-configuration-file’."
+  :type '(repeat string)
+  :risky t
+  :group 'bazel)
+
+(defcustom bazel-command-options nil
+  "Command-line options for all Bazel commands.
+The commands ‘bazel-build’, ‘bazel-test’ etc. insert these
+options after the command (‘build’, ‘test’, etc.); see URL
+‘https://docs.bazel.build/user-manual.html#options’.
+To add startup options, use the option ‘bazel-command’ instead.
+Instead of specifying startup options here, it’s typically
+preferable to use a ‘.bazelrc’ file instead; see URL
+‘https://docs.bazel.build/guide.html#bazelrc-the-bazel-configuration-file’.
+Use this option only for Bazel options that are really
+Emacs-specific, such as ‘--tool_tag=emacs’."
   :type '(repeat string)
   :risky t
   :group 'bazel)
@@ -1738,9 +1759,14 @@ COMMAND is a Bazel command such as \"build\" or \"run\"."
   (cl-check-type target-pattern string)
   (bazel--compile command "--" target-pattern))
 
-(defun bazel--compile (&rest args)
-  "Run Bazel in a Compilation buffer with the given ARGS."
-  (compile (mapconcat #'shell-quote-argument (append bazel-command args) " ")))
+(defun bazel--compile (command &rest args)
+  "Run Bazel in a Compilation buffer with the given COMMAND and ARGS.
+Insert command options from ‘bazel-command-options’ between
+COMMAND and ARGS."
+  (compile (mapconcat #'shell-quote-argument
+                      (append bazel-command (list command)
+                              bazel-command-options args)
+                      " ")))
 
 (defvar bazel-target-history nil
   "History for Bazel target pattern completion.

--- a/test.el
+++ b/test.el
@@ -763,6 +763,15 @@ in ‘bazel-mode’."
     (bazel-build "//foo:bar")
     (should (equal commands '("bazel build -- //foo\\:bar")))))
 
+(ert-deftest bazel-run/options ()
+  (cl-letf* ((commands ())
+             ((symbol-function #'compile)
+              (lambda (command &optional _comint)
+                (push command commands)))
+             (bazel-command-options '("--tool_tag=emacs")))
+    (bazel-run "//foo:bar")
+    (should (equal commands '("bazel run --tool_tag\\=emacs -- //foo\\:bar")))))
+
 (ert-deftest bazel-build-mode/font-lock ()
   "Test Font Locking in ‘bazel-build-mode’."
   (let ((text (ert-propertized-string


### PR DESCRIPTION
This can be occasionally useful to specify Emacs-related options.