### PR TITLE
Fix ‘bazel-insert-http-archive’ if the URL lacks a filename.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -417,7 +417,9 @@ Return a list (NAME SHA-256 PREFIX TIME) for
 ‘bazel-insert-http-archive’."
   (cl-check-type url string)
   (let* ((temp-dir (make-temp-file "bazel-http-archive-" :directory))
-         (archive-file (expand-file-name (url-file-nondirectory url) temp-dir))
+         (name (url-file-nondirectory url))
+         (archive-file (expand-file-name
+                        (if (string-empty-p name) "archive" name) temp-dir))
          (reporter (make-progress-reporter
                     (format-message "Downloading %s into %s..." url temp-dir)))
          (coding-system-for-read 'no-conversion)


### PR DESCRIPTION
This happens e.g. for Gitweb snapshot URLS like
‘https://git.savannah.gnu.org/gitweb/?p=emacs/nongnu.git;a=snapshot;h=〈hash〉;sf=tgz’.
Instead of trying to guess a filename in that case, just use a constant one.