### PR TITLE
Fix various bugs with workspace name completion.

### DIFF
--- a/testdata/target-completion-workspace.org
+++ b/testdata/target-completion-workspace.org
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#+property: header-args :mkdirp yes :main no
+
+* Test target completion for external workspaces
+
+#+begin_src bazel-workspace :tangle main/WORKSPACE
+workspace(name = "main")
+#+end_src
+
+#+begin_src bazel-build :tangle main/BUILD
+# Dummy BUILD file
+#+end_src
+
+#+begin_src bazel-build :tangle main/main-pkg/BUILD
+# Dummy BUILD file
+#+end_src
+
+#+begin_src bazel-workspace :tangle main/bazel-main/external/ext/WORKSPACE
+workspace(name = "ext")
+#+end_src
+
+#+begin_src bazel-build :tangle main/bazel-main/external/ext/BUILD
+# Dummy BUILD file
+#+end_src
+
+#+begin_src bazel-build :tangle main/bazel-main/external/ext/ext-pkg/BUILD
+# Dummy BUILD file
+#+end_src


### PR DESCRIPTION
Workspace completion didn’t really work and wasn’t tested.  Add tests and fix
some bugs:

- Remove incorrect duplicate invocation of ‘bazel--external-workspace-dir’.

- Teach completion about the main workspace (“@//…” syntax).

- Better support the “@foo” syntax as shorthand for “@foo//:foo”.

- Consistently represent the main workspace with the empty string, and
  distinguish it from the current workspace.