### PR TITLE
Support Windows paths in compilation-mode

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1202,7 +1202,12 @@ Look for an imported file with the given NAME."
                       ;; don’t include spaces here either.  We do allow
                       ;; non-ASCII alphanumeric characters, because they could
                       ;; be part of the workspace directory name.
-                      (group (+ (any alnum ?/ ?- ?. ?_))
+                      ;;
+                      ;; This also needs to account for Windows-style paths,
+                      ;; which might need to account for the current drive, and
+                      ;; will start with something like "C:/".
+                      (group (optional (any (?A . ?Z) (?a . ?z)) ":/")
+                             (+ (any alnum ?/ ?- ?. ?_))
                              (or (seq "/BUILD" (? ".bazel"))
                                  (seq (+ (any alnum ?- ?. ?_)) ".bzl")))
                       ?: (group (+ digit)) ?: (group (+ digit)) ": ")

--- a/bazel.el
+++ b/bazel.el
@@ -1203,7 +1203,7 @@ Look for an imported file with the given NAME."
                       ;; non-ASCII alphanumeric characters, because they could
                       ;; be part of the workspace directory name.
                       ;;
-                      ;; This also needs to account for Windows-style paths,
+                      ;; This also needs to account for Windows-style file names,
                       ;; which might need to account for the current drive, and
                       ;; will start with something like "C:/".
                       (group (optional (any (?A . ?Z) (?a . ?z)) ":/")


### PR DESCRIPTION
The regexps added to `compilation-error-regexp-alist-alist` need to match paths
output by Bazel, which are subject to numerous constraints.  As currently
written, this does not support Windows paths, which, as output by Bazel, start
with a drive letter and a root path (e.g `C:/`).

Address this by extending the regexp to account for Windows paths.  UNIX-style
path processing should not be affected; tests passed there.

NOTE: I was not able to build the test suite on Windows, nor do there seem to be
instructions for doing so.  I'll be happy to discuss what I tried in the
PR, but I'm not exactly a Windows expert, nor do I currently do development on it regularly.