### PR TITLE
Mark completion operation as non-essential when coming from a timer.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1007,8 +1007,17 @@ See Info node ‘(elisp) Completion in Buffers’ for context."
                                   'syntax-table)
               (let ((end (1- (point))))
                 (when (>= end start)
-                  (when-let ((table (bazel--completion-at-point-table start)))
-                    (list start end table)))))))))))
+                  ;; A somewhat crude method to determine whether this operation
+                  ;; is deemed essential.  If it comes from a timer, assume it’s
+                  ;; something like Company idle completion.
+                  ;; https://github.com/company-mode/company-mode/pull/1288
+                  ;; should make this mostly obsolete.
+                  (let ((non-essential
+                         (or non-essential
+                             (and (backtrace-frame 0 #'timer-event-handler)
+                                  t))))
+                    (when-let ((table (bazel--completion-at-point-table start)))
+                      (list start end table))))))))))))
 
 (defun bazel--completion-at-point-table (start)
   "Return a completion table for ‘completion-at-point-functions’.


### PR DESCRIPTION
In that case, we shouldn’t block on opening remote connections or similar.