### PR TITLE
Don’t access the filesystem when construction completion tables.

### DIFF
--- a/test.el
+++ b/test.el
@@ -585,7 +585,7 @@ the rule."
            ("//...:" t "//...:" ("all" "all-targets" "*") nil 6)))
       (dolist (pattern (if (eq pattern '*) '(nil t) (list pattern)))
         (ert-info ((if pattern "yes" "no") :prefix "Pattern completion: ")
-          (let ((table (bazel--target-completion-table dir "" pattern nil)))
+          (let ((table (bazel--target-completion-table dir pattern nil)))
             (ert-info ((prin1-to-string string) :prefix "Input: ")
               (should (equal (try-completion string table) try))
               (should (equal (all-completions string table) all))
@@ -619,7 +619,7 @@ the rule."
            (":a" * ":all" ("all" "all-targets") nil 1)))
       (dolist (only-tests (if (eq only-tests '*) '(nil t) (list only-tests)))
         (ert-info ((if only-tests "yes" "no") :prefix "Only tests: ")
-          (let ((table (bazel--target-completion-table dir "" :pattern
+          (let ((table (bazel--target-completion-table dir :pattern
                                                        only-tests)))
             (ert-info ((prin1-to-string string) :prefix "Input: ")
               (should (equal (try-completion string table) try))
@@ -707,8 +707,9 @@ the rule."
           (should (consp packages))
           (dolist (package packages)
             (ert-info ((prin1-to-string package) :prefix "Package: ")
-              (let ((table (bazel--target-completion-table dir package
-                                                           :pattern nil)))
+              (let ((table (bazel--target-completion-table
+                            (expand-file-name package dir)
+                            :pattern nil)))
                 (should (equal (try-completion string table) try))
                 (should (equal (all-completions string table) all))
                 (should (eq (test-completion string table) test))


### PR DESCRIPTION
This is particularly important for ‘completion-at-point’.  As
https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html
explains, the functions added to ‘completion-at-point-functions’ “[…] should
generally return quickly, since they may be called very often (e.g., from
‘post-command-hook’)”.  Delay necessary filesystem access (finding the workspace
root and the current package) to later when it’s actually needed.