### PR TITLE
Show process status for failed Buildifier process.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -242,6 +242,13 @@ corresponding to the file types documented at URL
                   (kill-buffer buildifier-buffer))
               (with-temp-buffer-window buildifier-buffer nil nil
                 (insert-file-contents buildifier-error-file)
+                (goto-char (point-max))
+                (insert ?\n "Process buildifier "
+                        (if (stringp return-code)
+                            (downcase return-code)  ; signal name
+                          (format "exited abnormally with code %d" return-code))
+                        ?\n)
+                (goto-char (point-min))
                 (compilation-minor-mode))))))))
   nil)
 

--- a/test.el
+++ b/test.el
@@ -1076,6 +1076,8 @@ in ‘bazel-mode’."
         (ert-info ("Error buffer")
           (should (equal (buffer-string) "pkg/BUILD:3:1: syntax error
 pkg/BUILD # reformat
+
+Process buildifier exited abnormally with code 1
 ")))))))
 
 (ert-deftest bazel-buildifier-before-save ()


### PR DESCRIPTION
This mimics the behavior of asynchronous processes, and can be useful for
debugging.