### PR TITLE
Ensure that the Buildifier error buffer is in the right directory.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -223,6 +223,10 @@ corresponding to the file types documented at URL
       (with-current-buffer buildifier-buffer
         (setq-local inhibit-read-only t)
         (erase-buffer)
+        (when-let ((root (bazel--workspace-root (or input-file directory))))
+          ;; Files in Buildifier error messages are local to the workspace root.
+          ;; Make sure that ‘next-error’ finds them.
+          (setq-local default-directory root))
         (cl-flet ((maybe-unquote (if (< emacs-major-version 28)
                                      #'file-name-unquote  ; Bug#48177
                                    #'identity)))

--- a/test.el
+++ b/test.el
@@ -1074,6 +1074,7 @@ in ‘bazel-mode’."
       (should (eql (length temp-buffers) 1))
       (with-current-buffer (car temp-buffers)
         (ert-info ("Error buffer")
+          (should (bazel-test--file-equal-p default-directory dir))
           (should (equal (buffer-string) "pkg/BUILD:3:1: syntax error
 pkg/BUILD # reformat
 ")))))))


### PR DESCRIPTION
Otherwise ‘next-error’ won’t be able to find the files mentioned in the error
messages.