### PR TITLE
Make ‘bazel--run-bazel-command’ public and interactive.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1858,7 +1858,7 @@ Return nil if no .bazelignore file exists."
   "Build a Bazel TARGET."
   (interactive (list (bazel--read-target-pattern "build" nil)))
   (cl-check-type target string)
-  (bazel--run-bazel-command "build" target)
+  (bazel "build" target)
   nil)
 
 (defun bazel-compile-current-file ()
@@ -1876,14 +1876,14 @@ Return nil if no .bazelignore file exists."
   "Build and run a Bazel TARGET."
   (interactive (list (bazel--read-target-pattern "run" nil)))
   (cl-check-type target string)
-  (bazel--run-bazel-command "run" target)
+  (bazel "run" target)
   nil)
 
 (defun bazel-test (target)
   "Build and run a Bazel test TARGET."
   (interactive (list (bazel--read-target-pattern "test" :only-tests)))
   (cl-check-type target string)
-  (bazel--run-bazel-command "test" target)
+  (bazel "test" target)
   nil)
 
 (defun bazel-test-at-point ()
@@ -1915,12 +1915,18 @@ Return nil if no .bazelignore file exists."
   "Run Bazel test TARGET with coverage instrumentation enabled."
   (interactive (list (bazel--read-target-pattern "coverage" :only-tests)))
   (cl-check-type target string)
-  (bazel--run-bazel-command "coverage" target)
+  (bazel "coverage" target)
   nil)
 
-(defun bazel--run-bazel-command (command target-pattern)
+(defun bazel (command target-pattern)
   "Run Bazel tool with given COMMAND on the given TARGET-PATTERN.
-COMMAND is a Bazel command such as \"build\" or \"run\"."
+COMMAND is a Bazel command such as \"build\" or \"run\".
+Interactively, prompt for COMMAND and TARGET-PATTERN, with
+completion."
+  (interactive (let* ((command (bazel--read-command))
+                      (only-tests (member command '("test coverage")))
+                      (targets (bazel--read-target-pattern command only-tests)))
+                 (list command targets)))
   (cl-check-type command string)
   (cl-check-type target-pattern string)
   (bazel--compile command "--" target-pattern))
@@ -1933,6 +1939,14 @@ COMMAND and ARGS."
                       (append bazel-command (list command)
                               bazel-command-options args)
                       " ")))
+
+(defun bazel--read-command ()
+  "Read a Bazel command name from the minibuffer, with completion."
+  ;; See https://docs.bazel.build/versions/5.0.0/command-line-reference.html#commands
+  ;; for the list of commands.  We only offer a reasonable subset here.
+  (completing-read "Command (default ‘build’): "
+                   '("build" "test" "coverage" "run" "fetch")
+                   nil nil nil nil "build"))
 
 (defvar bazel-target-history nil
   "History for Bazel target pattern completion.

--- a/manual.org
+++ b/manual.org
@@ -100,6 +100,7 @@ saving, customize the user option ~bazel-buildifier-before-save~ to ~t~.
 
 * Running Bazel
 
+#+FINDEX: bazel
 #+FINDEX: bazel-build
 #+FINDEX: bazel-test
 #+FINDEX: bazel-coverage
@@ -113,7 +114,8 @@ To simplify running Bazel commands, the package provides the commands
 the corresponding Bazel commands in a compilation mode buffer.  In a
 ~bazel-mode~ buffer, you can use the keys =C-c C-b=, =C-c C-t=, =C-c C-c=, and
 =C-c C-r= to run these commands, respectively.  These commands provide
-minibuffer completion for Bazel target patterns.
+minibuffer completion for Bazel target patterns.  There’s also the generic
+command ~bazel~, which prompts for the command to run.
 
 #+FINDEX: bazel-test-at-point
 In a buffer that visits a test file, you can also have Emacs try to detect and
@@ -215,7 +217,7 @@ completion framework]].  To disable Ivy for the affected commands, add
 something like the following to your Emacs initialization file.
 
 #+BEGIN_SRC emacs-lisp
-(dolist (function '(bazel-build bazel-run bazel-test bazel-coverage))
+(dolist (function '(bazel bazel-build bazel-run bazel-test bazel-coverage))
   (add-to-list 'ivy-completing-read-handlers-alist
                `(,function . completing-read-default)))
 #+END_SRC


### PR DESCRIPTION
Since we have this function anyway, there’s little added complexity and risk in
exposing it to the user.