### PR TITLE
Consistently use uppercase letters for Org properties and keywords.

### DIFF
--- a/testdata/bazelrc.org
+++ b/testdata/bazelrc.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazelrc :tangle .bazelrc
+#+BEGIN_SRC bazelrc :tangle .bazelrc
 import %workspace%/other.bazelrc
-#+end_src
+#+END_SRC
 
-#+begin_src bazelrc :tangle other.bazelrc
+#+BEGIN_SRC bazelrc :tangle other.bazelrc
 build --verbose_failures
-#+end_src
+#+END_SRC

--- a/testdata/buildifier.org
+++ b/testdata/buildifier.org
@@ -12,31 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-buildifier~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+name: build
-#+begin_src bazel-build :tangle pkg/BUILD
+#+NAME: build
+#+BEGIN_SRC bazel-build :tangle pkg/BUILD
 cc_library(
-#+end_src
+#+END_SRC
 
 To make the Buildifier test hermetic, we generate Buildifier output statically
 and tangle the output when running the test.  Execute this code block to
 regenerate the Buildifier output:
 
-#+begin_src sh :noweb yes :results output scalar :wrap "src fundamental :tangle buildifier.err"
+#+BEGIN_SRC sh :noweb yes :results output scalar :wrap "src fundamental :tangle buildifier.err"
 ! buildifier -type=build -path=pkg/BUILD 2>&1 <<'EOF'
 <<build>>
 EOF
-#+end_src
+#+END_SRC
 
 #+RESULTS:
-#+begin_src fundamental :tangle buildifier.err
+#+BEGIN_SRC fundamental :tangle buildifier.err
 pkg/BUILD:3:1: syntax error
 pkg/BUILD # reformat
-#+end_src
+#+END_SRC

--- a/testdata/compile.org
+++ b/testdata/compile.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,27 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle package/BUILD
+#+BEGIN_SRC bazel-build :tangle package/BUILD
 cc_library(
     name = "test",
     srcs = ["test.cc"],
     deprecation = "Deprecated!",
 )
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle package/test.cc
+#+BEGIN_SRC C++ :tangle package/test.cc
 UnknownType foo;
-#+end_src
+#+END_SRC
 
 Merged standard output and error from Bazel:
 
-#+begin_src fundamental :tangle bazel.out
+#+BEGIN_SRC fundamental :tangle bazel.out
 Loading: 
 Loading: 0 packages loaded
 WARNING: %ROOTDIR%/package/BUILD:1:11: target '//package:test' is deprecated: Deprecated!
@@ -57,4 +57,4 @@ INFO: Elapsed time: 1.702s, Critical Path: 0.04s
 INFO: 4 processes: 4 internal.
 FAILED: Build did NOT complete successfully
 FAILED: Build did NOT complete successfully
-#+end_src
+#+END_SRC

--- a/testdata/completion-at-point.org
+++ b/testdata/completion-at-point.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_library(
     name = "lib",
     srcs = ["lib.cc"],
@@ -27,4 +27,4 @@ cc_binary(
     srcs = ["bin.cc"],
     deps = ["//:li"],
 )
-#+end_src
+#+END_SRC

--- a/testdata/coverage.org
+++ b/testdata/coverage.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,34 +22,34 @@ coverage doesn’t work at all]].  Java coverage still
 [[https://github.com/bazelbuild/bazel/issues/13358][suffers from some bugs]],
 but can at least be made to work somewhat reliably.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_src
 
 We follow the
 [[https://docs.bazel.build/versions/4.1.0/bazel-and-java.html#best-practices][Java-specific
 best practices]].
 
-#+begin_src bazel-build :tangle src/main/java/example/BUILD
+#+BEGIN_SRC bazel-build :tangle src/main/java/example/BUILD
 java_library(
     name = "example",
     srcs = glob(["*.java"]),
     visibility = ["//src/test/java/example:__pkg__"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle src/test/java/example/BUILD
+#+BEGIN_SRC bazel-build :tangle src/test/java/example/BUILD
 java_test(
     name = "example_test",
     srcs = glob(["*.java"]),
     test_class = "example.ExampleTest",
     deps = ["//src/main/java/example"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src java :tangle src/main/java/example/Example.java
+#+BEGIN_SRC java :tangle src/main/java/example/Example.java
 package example;
 
 public class Example {
@@ -61,9 +61,9 @@ public class Example {
         }
     }
 }
-#+end_src
+#+END_SRC
 
-#+begin_src java :tangle src/test/java/example/ExampleTest.java
+#+BEGIN_SRC java :tangle src/test/java/example/ExampleTest.java
 package example;
 
 import static org.junit.Assert.assertEquals;
@@ -75,9 +75,9 @@ public class ExampleTest {
         assertEquals(137, Example.function(true));
     }
 }
-#+end_src
+#+END_SRC
 
-#+begin_src fundamental :tangle bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
+#+BEGIN_SRC fundamental :tangle bazel-out/k8-fastbuild/testlogs/src/test/java/example/example_test/coverage.dat
 SF:src/main/java/example/Example.java
 FN:3,example/Example::<init> ()V
 FN:5,example/Example::function (Z)I
@@ -96,11 +96,11 @@ DA:8,0
 LH:2
 LF:4
 end_of_record
-#+end_src
+#+END_SRC
 
 Merged standard output and error from Bazel:
 
-#+begin_src fundamental :tangle bazel.out
+#+BEGIN_SRC fundamental :tangle bazel.out
 Loading: 
 Loading: 0 packages loaded
 INFO: Using default value for --instrumentation_filter: "^//src/main/java/example[/:]".
@@ -128,4 +128,4 @@ INFO: Build completed successfully, 22 total actions
 Executed 1 out of 1 test: 1 test passes.
 There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
 INFO: Build completed successfully, 22 total actions
-#+end_src
+#+END_SRC

--- a/testdata/defun-navigation.org
+++ b/testdata/defun-navigation.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-build-mode/beginning-of-defun~ and ~bazel-build-mode/end-of-defun~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 # Some comment.
 
 elisp_library(
     name = "bazel",
     srcs = ["bazel.el"],
 )
-#+end_src
+#+END_SRC

--- a/testdata/find-file-at-point.org
+++ b/testdata/find-file-at-point.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,29 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes
+#+PROPERTY: header-args :mkdirp yes
 
 * Test data for the ~bazel-mode/ffap~ test
 
-#+begin_src bazel-workspace :tangle root/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle root/WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src C :tangle root/aaa.h
+#+BEGIN_SRC C :tangle root/aaa.h
 // Dummy file
-#+end_src
+#+END_SRC
 
-#+begin_src C :tangle root/pkg/aaa.c
+#+BEGIN_SRC C :tangle root/pkg/aaa.c
 #include "aaa.h"
 #include "bbb.h"
-#+end_src
+#+END_SRC
 
 Files in an external workspace:
 
-#+begin_src bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
 workspace(name = "ws")
-#+end_src
+#+END_SRC
 
-#+begin_src C :tangle root/bazel-root/external/ws/bbb.h
+#+BEGIN_SRC C :tangle root/bazel-root/external/ws/bbb.h
 // Dummy file
-#+end_src
+#+END_SRC

--- a/testdata/fix-visibility.org
+++ b/testdata/fix-visibility.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,40 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for the ~bazel-fix-visibility~ test
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_binary(
     name = "bin",
     srcs = ["bin.cc"],
     deps = ["//lib"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src c++ :tangle bin.cc
+#+BEGIN_SRC c++ :tangle bin.cc
 // Dummy C++ file
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle lib/BUILD
+#+BEGIN_SRC bazel-build :tangle lib/BUILD
 cc_library(
     name = "lib",
     srcs = ["lib.cc"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src c++ :tangle lib/lib.cc
+#+BEGIN_SRC c++ :tangle lib/lib.cc
 // Dummy C++ file
-#+end_src
+#+END_SRC
 
 ** Merged standard output and error from Bazel
 
-#+begin_src fundamental :tangle bazel.out
+#+BEGIN_SRC fundamental :tangle bazel.out
 Loading:
 Loading: 0 packages loaded
 Analyzing: 2 targets (2 packages loaded, 0 targets configured)
@@ -57,4 +57,4 @@ INFO: Elapsed time: 3,862s
 INFO: 0 processes.
 FAILED: Build did NOT complete successfully (17 packages loaded, 143 targets configured)
 FAILED: Build did NOT complete successfully (17 packages loaded, 143 targets configured)
-#+end_src
+#+END_SRC

--- a/testdata/flymake.org
+++ b/testdata/flymake.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,33 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-mode-flymake~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+name: starlark
-#+begin_src bazel-starlark :tangle buildifier.bzl
+#+NAME: starlark
+#+BEGIN_SRC bazel-starlark :tangle buildifier.bzl
 def foo(bar):
     """ """
     a = 1 / 2
-#+end_src
+#+END_SRC
 
 To make the Flymake test hermetic, we generate Buildifier output statically and
 tangle the output when running the test.  Execute this code block to regenerate
 the Buildifier output:
 
-#+begin_src sh :noweb yes :results output scalar :wrap "src js :tangle buildifier.json"
+#+BEGIN_SRC sh :noweb yes :results output scalar :wrap "src js :tangle buildifier.json"
 buildifier -mode=check -lint=warn -format=json -v -path=buildifier.bzl <<'EOF'
 <<starlark>>
 EOF
-#+end_src
+#+END_SRC
 
 #+RESULTS:
-#+begin_src js :tangle buildifier.json
+#+BEGIN_SRC js :tangle buildifier.json
 {
     "success": false,
     "files": [
@@ -93,13 +93,13 @@ EOF
         }
     ]
 }
-#+end_src
+#+END_SRC
 
 We also provide a “fake” Buildifier binary that only emits our canned output.
 It waits for the file =signal= to exist; you can use this to simulate a “slow”
 Buildifier.
 
-#+begin_src sh :tangle buildifier :shebang "#!/bin/bash" :var dir=(file-name-unquote (expand-file-name default-directory))
+#+BEGIN_SRC sh :tangle buildifier :shebang "#!/bin/bash" :var dir=(file-name-unquote (expand-file-name default-directory))
 # Fake waiting for file input.
 cat > /dev/null
 
@@ -110,4 +110,4 @@ done
 
 # Fake some Buildifier output.
 cat -- "${dir:?}/buildifier.json"
-#+end_src
+#+END_SRC

--- a/testdata/http-archive-invalid.org
+++ b/testdata/http-archive-invalid.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 ** Contents of the test repository archive
 
-#+begin_src fundamental :tangle archive.tar.gz
+#+BEGIN_SRC fundamental :tangle archive.tar.gz
 invalid archive contents
-#+end_src
+#+END_SRC

--- a/testdata/http-archive-no-unique-prefix.org
+++ b/testdata/http-archive-no-unique-prefix.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 ** Contents of the test repository archive
 
-#+begin_src bazel-workspace :tangle prefix-1/WORKSPACE :mkdirp yes
+#+BEGIN_SRC bazel-workspace :tangle prefix-1/WORKSPACE :mkdirp yes
 workspace(name = "test_repository_1")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-workspace :tangle prefix-2/WORKSPACE :mkdirp yes
+#+BEGIN_SRC bazel-workspace :tangle prefix-2/WORKSPACE :mkdirp yes
 workspace(name = "test_repository_2")
-#+end_src
+#+END_SRC

--- a/testdata/http-archive.org
+++ b/testdata/http-archive.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 We add a few quirks to the =WORKSPACE= file to ensure that the workspace name is
 correctly determined.
 
-#+begin_src bazel-workspace :tangle prefix/WORKSPACE :mkdirp yes
+#+BEGIN_SRC bazel-workspace :tangle prefix/WORKSPACE :mkdirp yes
 """
 workspace(name = "haha")
 """
@@ -29,17 +29,17 @@ workspace(name = "haha")
 workspace(foo = 'name = "no",', name = "test_repository")
 
 # workspace(name = "haha")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle prefix/BUILD :mkdirp yes
+#+BEGIN_SRC bazel-build :tangle prefix/BUILD :mkdirp yes
 # Empty BUILD file
-#+end_src
+#+END_SRC
 
 ** Expected ~http_workspace~ snippet
 
 The ~bazel-insert-http-archive~ test fakes a date of 2019-05-02.
 
-#+begin_src bazel-workspace :tangle WORKSPACE.expected
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE.expected
 http_archive(
     name = "test_repository",
     sha256 = "%sha256%",
@@ -48,4 +48,4 @@ http_archive(
         "%url%",  # 2019-05-02
     ],
 )
-#+end_src
+#+END_SRC

--- a/testdata/indent.org
+++ b/testdata/indent.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-mode/indent-region~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_library(
     name = "lib",
     srcs = [
@@ -39,4 +39,4 @@ cc_library(
         "bin-b",
     ]
 ]
-#+end_src
+#+END_SRC

--- a/testdata/project.org
+++ b/testdata/project.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes
+#+PROPERTY: header-args :mkdirp yes
 
 * Test data for project tests
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src fundamental :tangle bazel-out
+#+BEGIN_SRC fundamental :tangle bazel-out
 Dummy symbolic link
-#+end_src
+#+END_SRC
 
-#+begin_src bazelignore :tangle .bazelignore
+#+BEGIN_SRC bazelignore :tangle .bazelignore
 ignored-directory/
 # comment
 ignored directory # with number sign
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle package/BUILD
+#+BEGIN_SRC bazel-build :tangle package/BUILD
 cc_library(
     name = "lib",
     srcs = [
@@ -52,17 +52,17 @@ cc_binary(
         "//pkg:lib",
     ],
 )
-#+end_src
+#+END_SRC
 
 ** Files in ignored subdirectories
 
 The contents don’t matter; we add these files so that the directories are
 created.
 
-#+begin_src bazel-build :tangle ignored-directory/BUILD
+#+BEGIN_SRC bazel-build :tangle ignored-directory/BUILD
 # Empty file
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle "ignored directory # with number sign/BUILD"
+#+BEGIN_SRC bazel-build :tangle "ignored directory # with number sign/BUILD"
 # Empty file
-#+end_src
+#+END_SRC

--- a/testdata/speedbar.org
+++ b/testdata/speedbar.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-mode/speedbar~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 # Some comment.
-#+end_src
+#+END_SRC

--- a/testdata/target-completion-package.org
+++ b/testdata/target-completion-package.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle package/BUILD
+#+BEGIN_SRC bazel-build :tangle package/BUILD
 cc_library(
     name = "test",
     srcs = ["test.cc"],
     deprecation = "Deprecated!",
 )
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle package/test.cc
+#+BEGIN_SRC C++ :tangle package/test.cc
 UnknownType foo;
-#+end_src
+#+END_SRC

--- a/testdata/target-completion-root.org
+++ b/testdata/target-completion-root.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+begin_src bazel-workspace :tangle WORKSPACE :main no
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE :main no
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_library(
     name = "test",
     srcs = ["test.cc"],
@@ -27,16 +27,16 @@ py_test(
     name = "foo_test",
     srcs = ["foo_test.py"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle test.cc
+#+BEGIN_SRC C++ :tangle test.cc
 UnknownType foo;
-#+end_src
+#+END_SRC
 
-#+begin_src python :tangle foo_test.py
+#+BEGIN_SRC python :tangle foo_test.py
 import unittest
 
 class FooTest(unittest.TestCase):
     def testFoo(self):
         self.assertEquals(1, 2)
-#+end_src
+#+END_SRC

--- a/testdata/target-completion-workspace.org
+++ b/testdata/target-completion-workspace.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,30 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test target completion for external workspaces
 
-#+begin_src bazel-workspace :tangle main/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle main/WORKSPACE
 workspace(name = "main")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle main/BUILD
+#+BEGIN_SRC bazel-build :tangle main/BUILD
 # Dummy BUILD file
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle main/main-pkg/BUILD
+#+BEGIN_SRC bazel-build :tangle main/main-pkg/BUILD
 # Dummy BUILD file
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-workspace :tangle main/bazel-main/external/ext/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle main/bazel-main/external/ext/WORKSPACE
 workspace(name = "ext")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle main/bazel-main/external/ext/BUILD
+#+BEGIN_SRC bazel-build :tangle main/bazel-main/external/ext/BUILD
 # Dummy BUILD file
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle main/bazel-main/external/ext/ext-pkg/BUILD
+#+BEGIN_SRC bazel-build :tangle main/bazel-main/external/ext/ext-pkg/BUILD
 # Dummy BUILD file
-#+end_src
+#+END_SRC

--- a/testdata/test-at-point-c++.org
+++ b/testdata/test-at-point-c++.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_test(
     name = "cc_test",
     srcs = ["cc_test.cc"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle cc_test.cc
+#+BEGIN_SRC C++ :tangle cc_test.cc
 // Comment
 TEST(FooTest, Bar) {
   EXPECT_EQ(1, 2);
@@ -33,4 +33,4 @@ TEST(FooTest, Bar) {
 TEST_F(BazTest, Qux) {
   EXPECT_EQ(4, 5);
 }
-#+end_src
+#+END_SRC

--- a/testdata/test-at-point-elisp.org
+++ b/testdata/test-at-point-elisp.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 elisp_library(
     name = "foo",
     srcs = ["foo.el"],
@@ -28,15 +28,15 @@ elisp_test(
     name = "foo_test",
     srcs = ["foo-test.el"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src emacs-lisp :tangle foo.el
+#+BEGIN_SRC emacs-lisp :tangle foo.el
 (ert-deftest foo/not-really-a-test ()
   (should (foo)))
-#+end_src
+#+END_SRC
 
-#+begin_src emacs-lisp :tangle foo-test.el
+#+BEGIN_SRC emacs-lisp :tangle foo-test.el
 ;; Comment that is not a test.
 (ert-deftest foo/test ()
   (should (foo)))
-#+end_src
+#+END_SRC

--- a/testdata/test-at-point-go.org
+++ b/testdata/test-at-point-go.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 go_test(
     name = "go_test",
     srcs = ["go_test.go"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src go :tangle go_test.go
+#+BEGIN_SRC go :tangle go_test.go
 // Comment
 func Test(t *testing.T) {
         t.Error("Failed!")
@@ -33,4 +33,4 @@ func Test(t *testing.T) {
 func BenchmarkFoo_Bar(b *testing.B) {
         b.Error("Failed!")
 }
-#+end_src
+#+END_SRC

--- a/testdata/test-at-point-python.org
+++ b/testdata/test-at-point-python.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 py_test(
     name = "py_test",
     srcs = ["py_test.py"],
 )
-#+end_src
+#+END_SRC
 
-#+begin_src python :tangle py_test.py
+#+BEGIN_SRC python :tangle py_test.py
 # Comment
 
 from absl.testing import absltest
@@ -41,4 +41,4 @@ class MyTest(absltest.TestCase):
 
 if __name__ == '__main__':
     absltest.main()
-#+end_src
+#+END_SRC

--- a/testdata/which-function.org
+++ b/testdata/which-function.org
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
 * Test data for ~bazel-starlark-mode/which-function~
 
-#+begin_src bazel-workspace :tangle WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
 workspace(name = "test")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle BUILD
+#+BEGIN_SRC bazel-build :tangle BUILD
 cc_library(
     name = "lib",
     srcs = [
@@ -48,9 +48,9 @@ cc_binary(
 #     name = "bin",
 #     srcs = "bin.cc",
 # )
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-starlark :tangle defs.bzl
+#+BEGIN_SRC bazel-starlark :tangle defs.bzl
 # Comment
 
 looks_like_a_rule(
@@ -62,4 +62,4 @@ def foo(bar):
     def inner():
         in_inner = 1
     in_foo = 2
-#+end_src
+#+END_SRC

--- a/testdata/xref.org
+++ b/testdata/xref.org
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#+property: header-args :mkdirp yes :main no
+#+PROPERTY: header-args :mkdirp yes :main no
 
-#+begin_src bazel-workspace :tangle root/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle root/WORKSPACE
 workspace(name = "root")
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle root/BUILD
+#+BEGIN_SRC bazel-build :tangle root/BUILD
 cc_library(
     name = "lib",
     srcs = [
@@ -46,32 +46,32 @@ cc_binary(
 #     name = "bin",
 #     srcs = "bin.cc",
 # )
-#+end_src
+#+END_SRC
 
 Create empty files that the labels in the test BUILD file refer to.
 
-#+begin_src C++ :tangle root/aaa.cc
+#+BEGIN_SRC C++ :tangle root/aaa.cc
 // empty
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle root/dir/bbb.cc
+#+BEGIN_SRC C++ :tangle root/dir/bbb.cc
 // empty
-#+end_src
+#+END_SRC
 
-#+begin_src bazel-build :tangle root/pkg/BUILD
+#+BEGIN_SRC bazel-build :tangle root/pkg/BUILD
 # empty
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle root/pkg/ccc.cc
+#+BEGIN_SRC C++ :tangle root/pkg/ccc.cc
 // empty
-#+end_src
+#+END_SRC
 
 Files in an external workspace:
 
-#+begin_src bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
+#+BEGIN_SRC bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
 # empty
-#+end_src
+#+END_SRC
 
-#+begin_src C++ :tangle root/bazel-root/external/ws/pkg/ddd.cc
+#+BEGIN_SRC C++ :tangle root/bazel-root/external/ws/pkg/ddd.cc
 // empty
-#+end_src
+#+END_SRC


### PR DESCRIPTION
These aren’t case-sensitive, but it’s good to be internally consistent, and the
Org manual always uses the uppercase versions.