### PR TITLE
Require at least Emacs 27.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -2,7 +2,7 @@
 
 ;; URL: https://github.com/bazelbuild/emacs-bazel-mode
 ;; Keywords: build tools, languages
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; Version: 0
 
 ;; Copyright (C) 2018-2022 Google LLC

--- a/obsolete/bazel-mode.el
+++ b/obsolete/bazel-mode.el
@@ -2,10 +2,10 @@
 
 ;; URL: https://github.com/bazelbuild/emacs-bazel-mode
 ;; Keywords: build tools, languages
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; Version: 0
 
-;; Copyright (C) 2018, 2021 Google LLC
+;; Copyright (C) 2018, 2021, 2022 Google LLC
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
 ;; You may obtain a copy of the License at

--- a/obsolete/bazelrc-mode.el
+++ b/obsolete/bazelrc-mode.el
@@ -2,10 +2,10 @@
 
 ;; URL: https://github.com/bazelbuild/emacs-bazel-mode
 ;; Keywords: build tools, languages
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; Version: 0
 
-;; Copyright 2020, 2021 Google LLC
+;; Copyright 2020, 2021, 2022 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.


### PR DESCRIPTION
Now that Emacs 28 has been released, I think it makes sense to drop support for
Emacs 26.  rules_elisp doesn’t support it any more, and dropping support means
we can remove quite a few workarounds.  If this PR is accepted, I’ll remove the
workarounds in follow-up PRs.