### PR TITLE
Add a temporary workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44481

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -26,6 +26,12 @@
 
 ;;; Code:
 
+;; Work around Bug#44481.
+;; TODO(phst): Add this workaround to rules_elisp instead.
+(eval-and-compile
+  (when (version< emacs-version "27.2")
+    (define-advice system-name (:after-until ()) "")))
+
 (require 'cl-lib)
 (require 'compile)
 (require 'easymenu)


### PR DESCRIPTION
Otherwise byte compilation breaks under Emacs 27.1 with newer versions of
rules_elisp.