### PR TITLE
Use current Emacs version in make_*_out scripts.

### DIFF
--- a/testdata/make_compile_out
+++ b/testdata/make_compile_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, 2021 Google LLC
+# Copyright 2020, 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 set -eu
 
 # Bazel formats output differently when invoked from Emacs.
-export INSIDE_EMACS='26.1,compile'
+export INSIDE_EMACS='28.1,compile'
 
 workspace="$(bazel info workspace)" || exit
 testdata="${workspace:?}/testdata"

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 set -eu
 
 # Bazel formats output differently when invoked from Emacs.
-export INSIDE_EMACS='27.2,compile'
+export INSIDE_EMACS='28.1,compile'
 
 workspace="$(bazel info workspace)" || exit
 testdata="${workspace:?}/testdata"

--- a/testdata/make_fix_visibility_out
+++ b/testdata/make_fix_visibility_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, 2021 Google LLC
+# Copyright 2020, 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 set -eu
 
 # Bazel formats output differently when invoked from Emacs.
-export INSIDE_EMACS='27.2,compile'
+export INSIDE_EMACS='28.1,compile'
 
 workspace="$(bazel info workspace)" || exit
 testdata="${workspace:?}/testdata"


### PR DESCRIPTION
This shouldn’t have any semantic effect, but is a bit less confusing.