### PR TITLE
Fix target pattern prompt.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1954,7 +1954,7 @@ prompt.  If ONLY-TESTS is non-nil, look only for test rules."
          (package-name (or (bazel--package-name directory workspace-root)
                            (user-error "File is not in a Bazel package")))
          (prompt (combine-and-quote-strings
-                  `(,@bazel-command "--" ,command "")))
+                  `(,@bazel-command ,command "--" "")))
          (table (bazel--target-completion-table :pattern only-tests))
          (default (bazel--target-completion-default
                    buffer-file-name workspace-root package-name only-tests)))

--- a/test.el
+++ b/test.el
@@ -1347,7 +1347,7 @@ Process buildifier exited abnormally with code 1
                     (push command compile-commands))))
         (call-interactively #'bazel-test)
         (pcase completing-read-args
-          (`(("bazel -- test " ,_ nil nil nil bazel-target-history
+          (`(("bazel test -- " ,_ nil nil nil bazel-target-history
               "//:foo_test" nil)))
           (_ (ert-fail (list "Invalid arguments to ‘completing-read’"
                              completing-read-args))))


### PR DESCRIPTION
Right now this produces prompts such as

    bazel -- test

but correct would be

    bazel test --