### PR TITLE
Use keyword-only form for :noinline structure option.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1773,7 +1773,7 @@ Return nil if no name was found.  This function is useful as
 
 ;; Inlining accessors would break clients that are compiled against a version
 ;; with an incompatible layout.
-(cl-defstruct (bazel-workspace (:noinline t))
+(cl-defstruct (bazel-workspace :noinline)
   "Represents a Bazel workspace."
   (root nil
         :read-only t


### PR DESCRIPTION
Edebug doesn’t detect the list form before commit
f3df7916b2b342380930082cf35bad6cb488a4dc, and that commit is not present in any released version of Emacs.