### PR TITLE
bazel-insert-http-archive: Support more forms of archives.

### DIFF
--- a/testdata/http-archive-no-directory.org
+++ b/testdata/http-archive-no-directory.org
@@ -1,0 +1,21 @@
+# Copyright 2021, 2022, 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+* Test data for the ~bazel-insert-http-archive/no-directory~ test
+
+** Contents of the test repository archive
+
+#+BEGIN_SRC bazel-workspace :tangle WORKSPACE
+workspace(name = "test_repository")
+#+END_SRC


### PR DESCRIPTION
Add support for archives that don’t contain exactly one directory.  For such archives, prompt the user for a prefix to strip.