### PR TITLE
Fix incorrect use of ‘cl-case’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1588,7 +1588,7 @@ See Info node ‘(elisp) Display Margins’."
            (let ((string (cl-loop for (_ . hits) in (sort branch-list
                                                           #'car-less-than-car)
                                   concat (cl-case hits
-                                           (nil "?")
+                                           ((nil) "?")
                                            (0 minus)
                                            (otherwise plus)))))
              (push (cons block-index string) block-list)))))


### PR DESCRIPTION
A case of ‘nil’ is interpreted as an empty key list and therefore never matches. See https://www.gnu.org/software/emacs/manual/html_node/cl/Conditionals.html.