### PR TITLE
Use URLs for bugs.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,6 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((emacs-lisp-mode . ((mode . bug-reference-prog)
-                     (bug-reference-url-format . "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=%s")))
- (org-mode . ((org-adapt-indentation . nil)
+((org-mode . ((org-adapt-indentation . nil)
               (org-edit-src-content-indentation . 0)))
  (nil . ((fill-column . 80))))

--- a/bazel.el
+++ b/bazel.el
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-;; Work around Bug#44481.
+;; Work around https://bugs.gnu.org/44481.
 ;; TODO(phst): Add this workaround to rules_elisp instead.
 (eval-and-compile
   (when (version< emacs-version "27.2")
@@ -222,7 +222,8 @@ corresponding to the file types documented at URL
       (let* ((default-directory directory)
              (temporary-file-directory
               (if (< emacs-major-version 28)
-                  (file-name-unquote temporary-file-directory)  ; Bug#48177
+                  ;; https://bugs.gnu.org/48177
+                  (file-name-unquote temporary-file-directory)
                 temporary-file-directory))
              (inhibit-read-only t)
              (process-file-side-effects t)
@@ -2269,7 +2270,7 @@ completion to test targets.  This is a helper function for
   (cl-check-type package string)
   (cl-check-type string string)
   ;; The cases below shouldn’t rebind the PACKAGE or ROOT parameters due to
-  ;; Bug#53071.
+  ;; https://bugs.gnu.org/53071.
   (pcase string
     ;; The following patterns should cover all potential target patterns from
     ;; https://bazel.build/run/build#specifying-build-targets as well as their
@@ -2305,7 +2306,7 @@ completion to test targets.  This is a helper function for
      ;; be completed to “//”.
      (bazel--completion-table-with-prefix prefix '("//")))
     ((rx bos
-         ;; Can’t use ‘(? … (let …))’ due to Bug#44532.
+         ;; Can’t use ‘(? … (let …))’ due to https://bugs.gnu.org/44532.
          (opt ?@ (let workspace (* (not (any ?: ?/))))) "//"
          eos)
      ;; In the workspace root, offer “:” to start completing rules, as well as
@@ -2324,7 +2325,7 @@ completion to test targets.  This is a helper function for
      (when pattern
        (bazel--completion-table-with-prefix prefix '("..."))))
     ((rx bos
-         ;; Can’t use ‘(? … (let …))’ due to Bug#44532.
+         ;; Can’t use ‘(? … (let …))’ due to https://bugs.gnu.org/44532.
          (opt ?@ (let workspace (+ (not (any ?: ?/))))) "//"
          (let pkg (+ (not (any ?:)))) ?/
          eos)
@@ -2335,7 +2336,7 @@ completion to test targets.  This is a helper function for
                                                pattern)))
     ((rx bos
          (let prefix
-           ;; Can’t use ‘(? … (let …))’ due to Bug#44532.
+           ;; Can’t use ‘(? … (let …))’ due to https://bugs.gnu.org/44532.
            (opt ?@ (let workspace (* (not (any ?: ?/))))) "//"
            (let pkg (* (not (any ?:))))
            ?:)
@@ -2347,7 +2348,7 @@ completion to test targets.  This is a helper function for
        (bazel--target-completion-table-2 root (or workspace "") pkg pattern
                                          only-tests nil)))
     ((rx bos
-         ;; Can’t use ‘(? … (let …))’ due to Bug#44532.
+         ;; Can’t use ‘(? … (let …))’ due to https://bugs.gnu.org/44532.
          (let prefix (opt ?@ (let workspace (* (not (any ?: ?/))))) "//")
          (+ (not (any ?:)))
          eos)
@@ -2790,7 +2791,7 @@ The returned completion table completes strings of the form
 
 (defalias 'bazel--json-parse-buffer
   (if (and (fboundp 'json-parse-buffer)
-           ;; Work around Bug#48228.
+           ;; Work around https://bugs.gnu.org/48228.
            (or (not (eq system-type 'windows-nt))
                (and (fboundp 'json-serialize)
                     (stringp (ignore-errors (json-serialize nil))))))

--- a/test.el
+++ b/test.el
@@ -251,7 +251,7 @@ gets killed early."
                                      (marker-buffer
                                       (xref-location-marker
                                        (xref-item-location def))))))
-                      ;; Work around Bug#46219.
+                      ;; Work around https://bugs.gnu.org/46219.
                       (cl-callf file-name-unquote root)
                       (cl-callf file-name-unquote ref-file)
                       (push (list (substring-no-properties identifier)
@@ -416,7 +416,8 @@ gets killed early."
           (when (< 4 (point) (- (point-max) 5)) (should in-string-p))
           (should-not in-comment-p)
           ;; The syntactic start of a triple-quoted string could be on the first
-          ;; (Emacs 27) or the last (Emacs 28) quote, cf. Bug#49518.
+          ;; (Emacs 27) or the last (Emacs 28) quote,
+          ;; cf. https://bugs.gnu.org/49518.
           (should (eq (not in-string-p) (not string-start))))
         (should (eq (face-at-point)
                     (and (< (point) (1- (point-max))) 'font-lock-string-face)))
@@ -441,11 +442,12 @@ gets killed early."
 
 (ert-deftest bazel/project-files ()
   "Test ‘project-files’ support for Bazel workspaces."
-  ;; Try to work around Bug#48471 by picking GNU find on macOS.
+  ;; Try to work around https://bugs.gnu.org/48471 by picking GNU find on macOS.
   (let ((find-program (if (eq system-type 'darwin) "gfind" find-program)))
     (skip-unless (executable-find find-program))
     (bazel-test--with-temp-directory dir "project.org"
-      (let* ((dir (file-name-unquote dir))  ; unquote to work around Bug#47799
+      ;; Unquote to work around https://bugs.gnu.org/47799.
+      (let* ((dir (file-name-unquote dir))
              (project (project-current nil dir))
              (files (project-files project)))
         (should project)


### PR DESCRIPTION
This is more universal and obvious than relying on ‘bug-reference-mode’.