### PR TITLE
Add command for finding the MODULE.bazel file.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -707,6 +707,7 @@ and Info node ‘(elisp) Syntax Table Internals’."
    ["Show consuming rule" bazel-show-consuming-rule]
    ["Find BUILD file" bazel-find-build-file]
    ["Find WORKSPACE file" bazel-find-workspace-file]
+   ["Find MODULE.bazel file" bazel-find-module-file]
    ["Format buffer with Buildifier" bazel-buildifier
     (derived-mode-p 'bazel-mode)]
    ["Insert http_archive statement..." bazel-insert-http-archive
@@ -1259,6 +1260,19 @@ restrict the returned rules to test targets."
           (or (bazel--locate-workspace-file root)
               (user-error "No WORKSPACE file found"))))
     (find-file workspace-file))
+  nil)
+
+(defun bazel-find-module-file ()
+  "Find the MODULE.bazel file for the current Bazel workspace."
+  (interactive)
+  (let* ((source-file
+          (or buffer-file-name default-directory
+              (user-error "Buffer doesn’t visit a file or directory")))
+         (root (or (bazel--workspace-root source-file)
+                   (user-error "File is not in a Bazel workspace")))
+         (module-file (or (locate-file "MODULE.bazel" (list root))
+                          (user-error "No MODULE.bazel file found"))))
+    (find-file module-file))
   nil)
 
 ;;;; ‘find-file-at-point’ support for ‘bazel-mode’

--- a/manual.org
+++ b/manual.org
@@ -171,9 +171,11 @@ information about ~find-file-at-point~, see [[info:Emacs#FFAP][FFAP]].
 
 #+FINDEX: bazel-find-build-file
 #+FINDEX: bazel-find-workspace-file
+#+FINDEX: bazel-find-module-file
 To visit the BUILD file that defines the package for the current file, run the
-command ~bazel-find-build-file~.  Similarly, to find the Bazel WORKSPACE file,
-run ~bazel-find-workspace-file~.
+command ~bazel-find-build-file~.  Similarly, to find the Bazel WORKSPACE or
+MODULE.bazel files, run ~bazel-find-workspace-file~ or ~bazel-find-module-file~,
+respectively.
 
 #+FINDEX: bazel-show-consuming-rule
 To find out which Bazel rule consumes the file that the current buffer visits,

--- a/test.el
+++ b/test.el
@@ -1350,6 +1350,21 @@ Process buildifier exited abnormally with code 1
               (should (file-equal-p buffer-file-name
                                     (expand-file-name expected dir))))))))))
 
+(ert-deftest bazel-find-module-file ()
+  (bazel-test--with-temp-directory dir nil
+    (dolist (file '("WORKSPACE" "MODULE.bazel"))
+      (write-region "" nil (expand-file-name file dir) nil nil nil 'excl))
+    (let ((expected (expand-file-name "MODULE.bazel" dir)))
+      (dolist (parent '("" "dir"))
+        (ert-info (parent :prefix "Parent directory: ")
+          (with-temp-buffer
+            (let ((buffer-file-name
+                   (expand-file-name "test.cc" (expand-file-name parent dir))))
+              (bazel-test--with-buffers
+                (bazel-find-module-file)
+                (should buffer-file-name)
+                (should (file-equal-p buffer-file-name expected))))))))))
+
 (ert-deftest bazelignore-mode/font-lock ()
   "Test Font Locking in ‘bazelignore-mode’."
   (let ((text (ert-propertized-string


### PR DESCRIPTION
This is analogous to the existing ‘bazel-find-workspace-file’.