### PR TITLE
Mark ‘bazel-buildifier’ as specific to Bazel files.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -209,7 +209,7 @@ and visited filename, if available.  Otherwise, TYPE must be one
 of the symbols ‘build’, ‘bzl’, ‘workspace’, ‘module’, or
 ‘default’, corresponding to the file types documented at URL
 ‘https://github.com/bazelbuild/buildtools/tree/master/buildifier#usage’."
-  (interactive "*")
+  (interactive "*" bazel-mode)
   (cl-check-type type (member nil build bzl workspace default))
   (let ((directory default-directory)
         (input-file buffer-file-name)


### PR DESCRIPTION
This causes the command to not show up in command completion lists unless the buffer is in one of the Bazel modes.