### PR TITLE
Remove use of obsolete ‘project-roots’.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -1832,11 +1832,6 @@ Otherwise, just evaluate BODY."
         `(with-suppressed-warnings ,warnings ,@body)
       (macroexp-progn body))))
 
-(bazel--with-suppressed-warnings ((obsolete project-roots))
-  (cl-defmethod project-roots ((project bazel-workspace))
-    "Return the primary root directory of the Bazel workspace PROJECT."
-    (list (bazel-workspace-root project))))
-
 (cl-defmethod project-external-roots ((project bazel-workspace))
   "Return the external workspace roots of the Bazel workspace PROJECT."
   (bazel--external-workspace-roots (bazel-workspace-root project)))

--- a/test.el
+++ b/test.el
@@ -434,10 +434,6 @@ gets killed early."
       (should (file-directory-p (bazel-workspace-root project)))
       (should (file-equal-p (bazel-workspace-root project) dir))
       (should (file-equal-p (project-root project) dir))
-      (bazel-test--with-suppressed-warnings ((obsolete project-roots))
-        (should (consp (project-roots project)))
-        (should-not (cdr (project-roots project)))
-        (should (file-equal-p (car (project-roots project)) dir)))
       (should-not (project-external-roots project)))))
 
 (ert-deftest bazel/project-files ()


### PR DESCRIPTION
The minimum supported version is now Emacs 28.1, and that already ships a project.el that marks ‘project-roots’ as obsolete (in favor of ‘project-root’).