### PR TITLE
Use ‘integrity’ instead of ‘sha256’.

### DIFF
--- a/test.el
+++ b/test.el
@@ -1155,6 +1155,13 @@ Process buildifier exited abnormally with code 1
                    ;; and Info node ‘(coreutils) md5sum invocation’.
                    (`(,(rx bos (let hash (+ xdigit)) ?\s))
                     ;; Replace variables in expected snippet with their values.
+                    (setq hash (base64-encode-string
+                                (replace-regexp-in-string
+                                 (rx xdigit xdigit)
+                                 (lambda (match)
+                                   (unibyte-string (string-to-number match 16)))
+                                 hash :fixedcase :literal)
+                                :no-line-break))
                     (dolist (pair `(("%sha256%" . ,hash)
                                     ("%url%" . ,url)))
                       (cl-destructuring-bind (variable . value) pair

--- a/testdata/http-archive.org
+++ b/testdata/http-archive.org
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ The ~bazel-insert-http-archive~ test fakes a date of 2019-05-02.
 #+BEGIN_SRC bazel-workspace :tangle WORKSPACE.expected
 http_archive(
     name = "test_repository",
-    sha256 = "%sha256%",
+    integrity = "sha256-%sha256%",
     strip_prefix = "prefix/",
     urls = [
         "%url%",  # 2019-05-02


### PR DESCRIPTION
‘integrity’ is extensible to newer/more secure hash functions.