### PR TITLE
Replace “workspace” with “repository” in many cases.

### DIFF
--- a/manual.org
+++ b/manual.org
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023 Google LLC
+# Copyright 2021, 2022, 2023, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -159,14 +159,14 @@ program (see
 If you don’t have BUILDOZER in your ~PATH~, you can customize the location of
 the Buildozer program though the user option ~bazel-buildozer-command~.
 
-* Files in Bazel workspaces
+* Files in Bazel repositories
 
-#+CINDEX: FFAP, for files in workspaces
-If you visit a file in a Bazel workspace, loading =bazel.el= will extend
-~find-file-at-point~ to search for files relative to the workspace root.  This
+#+CINDEX: FFAP, for files in repositories
+If you visit a file in a Bazel repository, loading =bazel.el= will extend
+~find-file-at-point~ to search for files relative to the repository root.  This
 allows you to use ~find-file-at-point~ to e.g. find included header files in C
 or C++ files that are built with Bazel.  This functionality also attempts to
-cover files in external repositories loaded by the current workspace.  For more
+cover files in external repositories loaded by the current repository.  For more
 information about ~find-file-at-point~, see [[info:Emacs#FFAP][FFAP]].
 
 #+FINDEX: bazel-find-build-file
@@ -182,8 +182,8 @@ BUILD file that has the source file in its list of source files and jump there.
 
 #+CINDEX: Projects
 =bazel.el= provides a project backend, ~bazel-find-project~.  By default, it
-will include all files in the Bazel workspace except the convenience symbolic
-links starting with =bazel-=.  You can exclude directories from the workspace
+will include all files in the Bazel repository except the convenience symbolic
+links starting with =bazel-=.  You can exclude directories from the repository
 project by adding them to the
 [[https://bazel.build/run/bazelrc#bazelignore][=.bazelignore= file]].  For more
 information about projects, see [[info:emacs#Projects][Projects]].

--- a/test.el
+++ b/test.el
@@ -1,6 +1,6 @@
 ;;; test.el --- unit tests for bazel.el  -*- lexical-binding: t; -*-
 
-;; Copyright 2020, 2021, 2022, 2023 Google LLC
+;; Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -460,7 +460,7 @@ gets killed early."
 
 (ert-deftest bazel-test/coverage ()
   "Test coverage parsing and display."
-  ;; Set up a fake workspace and execution root.  We use DIR for both.
+  ;; Set up a fake repository and execution root.  We use DIR for both.
   (bazel-test--with-temp-directory dir "coverage.org"
     (let* ((package-dir (expand-file-name "src/main/java/example" dir))
            (library (expand-file-name "Example.java" package-dir)))
@@ -716,9 +716,9 @@ gets killed early."
                 (should (equal (completion-boundaries string table nil "suffix")
                                (cons bound 6)))))))))))
 
-(ert-deftest bazel--target-completion-table/workspace ()
-  "Test workspace name completion."
-  (bazel-test--with-temp-directory dir "target-completion-workspace.org"
+(ert-deftest bazel--target-completion-table/repository ()
+  "Test repository name completion."
+  (bazel-test--with-temp-directory dir "target-completion-repository.org"
     (make-symbolic-link dir (expand-file-name "bazel-out" dir))
     ;; The test cases are of the form (STRING TRY ALL TEST BOUND).  STRING is
     ;; the input string.  TRY, ALL, and TEST are the expected results of

--- a/testdata/find-file-at-point.org
+++ b/testdata/find-file-at-point.org
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ workspace(name = "root")
 #include "bbb.h"
 #+END_SRC
 
-Files in an external workspace:
+Files in an external repository:
 
 #+BEGIN_SRC bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
 workspace(name = "ws")

--- a/testdata/make_compile_out
+++ b/testdata/make_compile_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, 2021, 2022 Google LLC
+# Copyright 2020, 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,14 +32,14 @@ trap 'rm -r -f -- "${dir}"' EXIT
 # choke on symbolic links.
 dir="$(realpath -e -- "${dir:?}")" || exit
 
-# Set up a basic workspace layout in the temporary directory.
+# Set up a basic repository layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
   --eval="(let ((default-directory \"${dir:?}/\")) (org-babel-tangle))" || exit
 
 execroot="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info execution_root)"
 
 # We explicitly compile with the current directory set to a subdirectory to
-# ensure that workspace-relative filenames still work as expected.  Invert the
+# ensure that repository-relative filenames still work as expected.  Invert the
 # exit status of “bazel build” because we expect it to fail.
 out="$(cd "${dir:?}/package" && ! bazel --bazelrc=/dev/null build //... 2>&1)"
 
@@ -47,7 +47,7 @@ out="$(cd "${dir:?}/package" && ! bazel --bazelrc=/dev/null build //... 2>&1)"
 out="${out//${dir}/%ROOTDIR%}"
 
 # The execution root is somewhere else, but since we only access source files,
-# we can virtually merge it with the workspace root.
+# we can virtually merge it with the repository root.
 out="${out//${execroot}/%ROOTDIR%}"
 
 # We can’t use ‘org-babel-detangle’ because there are no links in the tangled

--- a/testdata/make_coverage_out
+++ b/testdata/make_coverage_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ trap 'rm -r -f -- "${dir}"' EXIT
 # choke on symbolic links.
 dir="$(realpath -e -- "${dir:?}")" || exit
 
-# Set up a basic workspace layout in the temporary directory.
+# Set up a basic repository layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
   --eval="(let ((default-directory \"${dir:?}/\")) (org-babel-tangle))" || exit
 
@@ -45,7 +45,7 @@ execroot="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info execution_root)"
 testlogs="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info bazel-testlogs)"
 
 # We explicitly compile with the current directory set to a subdirectory to
-# ensure that workspace-relative filenames still work as expected.
+# ensure that repository-relative filenames still work as expected.
 out="$(cd "${dir:?}/src" && bazel --bazelrc=/dev/null coverage //... 2>&1)"
 
 # Parse output to find location of coverage.dat.  The output should be

--- a/testdata/make_fix_visibility_out
+++ b/testdata/make_fix_visibility_out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, 2021, 2022 Google LLC
+# Copyright 2020, 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,14 +32,14 @@ trap 'rm -r -f -- "${dir}"' EXIT
 # choke on symbolic links.
 dir="$(realpath -e -- "${dir:?}")" || exit
 
-# Set up a basic workspace layout in the temporary directory.
+# Set up a basic repository layout in the temporary directory.
 emacs --quick --batch --visit="${org:?}" \
   --eval="(let ((default-directory \"${dir:?}/\")) (org-babel-tangle))" || exit
 
 execroot="$(cd "${dir:?}" && bazel --bazelrc=/dev/null info execution_root)"
 
 # We explicitly compile with the current directory set to a subdirectory to
-# ensure that workspace-relative filenames still work as expected.  Invert the
+# ensure that repository-relative filenames still work as expected.  Invert the
 # exit status of “bazel build” because we expect it to fail.
 out="$(cd "${dir:?}/lib" && ! bazel --bazelrc=/dev/null build //... 2>&1)"
 
@@ -47,7 +47,7 @@ out="$(cd "${dir:?}/lib" && ! bazel --bazelrc=/dev/null build //... 2>&1)"
 out="${out//${dir}/%ROOTDIR%}"
 
 # The execution root is somewhere else, but since we only access source files,
-# we can virtually merge it with the workspace root.
+# we can virtually merge it with the repository root.
 out="${out//${execroot}/%ROOTDIR%}"
 
 # We can’t use ‘org-babel-detangle’ because there are no links in the tangled

--- a/testdata/target-completion-repository.org
+++ b/testdata/target-completion-repository.org
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 #+PROPERTY: header-args :mkdirp yes :main no
 
-* Test target completion for external workspaces
+* Test target completion for external repositories
 
 #+BEGIN_SRC bazel-workspace :tangle main/WORKSPACE
 workspace(name = "main")

--- a/testdata/xref.org
+++ b/testdata/xref.org
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ Create empty files that the labels in the test BUILD file refer to.
 // empty
 #+END_SRC
 
-Files in an external workspace:
+Files in an external repository:
 
 #+BEGIN_SRC bazel-workspace :tangle root/bazel-root/external/ws/WORKSPACE
 # empty


### PR DESCRIPTION
See https://bazel.build/concepts/build-ref#workspace and https://bazel.build/concepts/build-ref#repositories for correct terminology.