### PR TITLE
Add '~' to the list of characters allowed in external workspace roots.

### DIFF
--- a/bazel.el
+++ b/bazel.el
@@ -2219,7 +2219,7 @@ root directory as returned by ‘bazel--workspace-root’."
          ;; workspace names may only contain letters, numbers, and underscores,
          ;; but that’s wrong, since hyphens and dots are also allowed.  See
          ;; https://github.com/bazelbuild/bazel/blob/bc9fc6144818528898336c0fbe4fe8b30ac25abb/src/main/java/com/google/devtools/build/lib/packages/WorkspaceGlobals.java#L52.
-         (rx bos (any "A-Z" "a-z") (* (any ?- ?. ?_ "A-Z" "a-z")) eos))
+         (rx bos (any "A-Z" "a-z") (* (any ?- ?. ?~ ?_ "A-Z" "a-z")) eos))
       ;; If there’s no external workspace directory, don’t signal an error.
       (file-missing nil))))
 


### PR DESCRIPTION
This allows ffap to find files pulled in by a `bazel_dep()` declaration.

Tested manually by following the [current abseil-cpp quickstart for Bazel](https://github.com/abseil/abseil.github.io/blob/3d821c30eb5c00b95a76fa044a1a10ea94c587a1/docs/cpp/quickstart.md) and successfully running ffap on the include `"absl/strings/str_join.h"`.

I tried to update the unit tests, but I only got as far as getting `bazel test bazel_test` to fail during compilation of a sandbox emacs binary. (Details available on request.)